### PR TITLE
Fix pillar name of template

### DIFF
--- a/template/map.jinja
+++ b/template/map.jinja
@@ -26,7 +26,7 @@ that differ from whats in defaults.yaml
 
 {## Merge in template:lookup pillar ##}
 {% set template = salt['pillar.get'](
-        'template',
+        'template:lookup',
         default=default_settings.template,
         merge=True
     )


### PR DESCRIPTION
It should be `template:lookup`, even in the comment above it's
mentioned the correct pillar name :)