### PR TITLE
Use https in the link to SaltStack documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,13 +2,13 @@
 template-formula
 ================
 
-A saltstack formula that is empty. It has dummy content to help with a quick
+A SaltStack formula that is empty. It has dummy content to help with a quick
 start on a new formula.
 
 .. note::
 
     See the full `Salt Formulas installation and usage instructions
-    <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
+    <https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
 Available states
 ================


### PR DESCRIPTION
It is always better to use `https` wherever possible.

@aboe76 Please, would you be able to merge this in? Thank you.