### PR TITLE
 map.jinja: use grains.filter_by instead of defaults.merge

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 template formula
 ================
 
+0.1.3 (2019-02-12)
+
+- Use grains.filter_by instead of defaults.merge in map.jinja
+- Add osfingermap.yaml
+- Add tags and update VERSION and CHANGELOG
+
 0.1.2 (2019-02-12)
 
 - Update map.jinja, osfamilymap.yaml & osmap.yaml

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 # should contain the currently released version of the formula
-0.1.2
+0.1.3

--- a/template/map.jinja
+++ b/template/map.jinja
@@ -2,21 +2,21 @@
 # vim: ft=jinja
 
 {## Start imports as ##}
-{% import_yaml 'template/defaults.yaml' as defaults %}
+{% import_yaml 'template/defaults.yaml' as default_settings %}
 {% import_yaml 'template/osfamilymap.yaml' as osfamilymap %}
 {% import_yaml 'template/osmap.yaml' as osmap %}
+{% import_yaml 'template/osfingermap.yaml' as osfingermap %}
 
-{## Merge the osfamilymap ##}
-{% set osfamily = salt['grains.filter_by'](osfamilymap, grain='os_family') or {} %}
-{% do salt['defaults.merge'](defaults['template'], osfamily) %}
-
-{## Merge the osmap ##}
-{% set os = salt['grains.filter_by'](osmap, grain='os') or {} %}
-{% do salt['defaults.merge'](defaults['template'], os) %}
-
-{## Merge the lookup ##}
-{% set lookup = salt['pillar.get']('template:lookup', default={}) %}
-{% do salt['defaults.merge'](defaults['template'], lookup) %}
+{% set defaults = salt['grains.filter_by'](default_settings,
+    default='template',
+    merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
+      merge=salt['grains.filter_by'](osmap, grain='os',
+        merge=salt['grains.filter_by'](osfingermap, grain='osfinger',
+          merge=salt['pillar.get']('template:lookup', default={})
+        )
+      )
+    )
+) %}
 
 {## Merge the template pillar ##}
-{% set template = salt['pillar.get']('template', default=defaults['template'], merge=True) %}
+{% set template = salt['pillar.get']('template', default=defaults, merge=True) %}

--- a/template/osfingermap.yaml
+++ b/template/osfingermap.yaml
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+#
+# Setup variables using grains['osfinger'] based logic.
+# You just need to add the key:values for an `osfinger` that differ
+# from `defaults.yaml` + `os_family.yaml` + `osmap.yaml`.
+# Only add an `osfinger` which is/will be supported by the formula
+# (empty `osfinger`s do not need to be listed, just added here as an example).
+---
+CentOS-6:
+  pkg: template-centos-6
+  config: /etc/template.d/custom-centos-6.conf
+CentOS-7: {}


### PR DESCRIPTION
* map.jinja: use grains.filter_by instead of defaults.merge because defaults.merge does not work with salt-ssh. https://github.com/saltstack/salt/issues/51605
* Added osfingermap.yaml.
* Updated changelog and version. (Also set a tag in my repo, not sure how GitHub handles this.)