### PR TITLE
Improve TOFS implementation for increased configurability

### DIFF
--- a/template/config.sls
+++ b/template/config.sls
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{% from "template/map.jinja" import template with context %}
-{% from "template/macros.jinja" import files_switch with context %}
+{%- from "template/map.jinja" import template with context %}
+{%- from "template/macros.jinja" import files_switch with context %}
 
 include:
   - template.install
@@ -10,7 +10,13 @@ include:
 template-config:
   file.managed:
     - name: {{ template.config }}
-    - source: {{ files_switch('template', ['example.tmpl']) }}
+    - source: {{ files_switch(
+                    salt['config.get'](
+                        tpldir ~ ':tofs:files:template-config',
+                        ['example.tmpl', 'example.tmpl.jinja']
+                    )
+              ) }}
     - mode: 644
     - user: root
     - group: root
+    - template: jinja

--- a/template/files/default/example.tmpl.jinja
+++ b/template/files/default/example.tmpl.jinja
@@ -3,4 +3,4 @@
 # Your changes will be overwritten.
 ########################################################################
 
-This is an example file from SaltStack template-formula.
+This is another example file from SaltStack template-formula.

--- a/template/macros.jinja
+++ b/template/macros.jinja
@@ -1,8 +1,7 @@
-{%- macro files_switch(prefix,
-                       files,
+{%- macro files_switch(files,
                        default_files_switch=['id', 'os_family'],
                        indent_width=6) %}
-  {#
+  {#-
     Returns a valid value for the "source" parameter of a "file.managed"
     state function. This makes easier the usage of the Template Override and
     Files Switch (TOFS) pattern.
@@ -43,22 +42,42 @@
             - salt://xxx/files/default/etc/yyy/zzz.conf.jinja
           - template: jinja
   #}
-  {%- set path_prefix = prefix|replace(':', '/') %}
-  {%- set files_switch_list = salt['pillar.get'](prefix ~ ':files_switch',
-                                           default_files_switch) %}
-  {%- for grain in files_switch_list if grains.get(grain) is defined %}
-    {%- for file in files %}
-      {%- set url = '- salt://' ~ '/'.join([path_prefix,
-                                            'files',
-                                            grains.get(grain),
-                                            file.lstrip('/')]) %}
+  {#- Get the `topdir` from `tpldir` #}
+  {%- set topdir = tpldir.split('/')[0] %}
+  {%- set path_prefix = salt['config.get'](topdir ~ ':tofs:path_prefix', topdir) %}
+  {%- set files_dir = salt['config.get'](topdir ~ ':tofs:dirs:files', 'files') %}
+  {%- set files_switch_list = salt['config.get'](
+      topdir ~ ':tofs:files_switch',
+      default_files_switch
+  ) %}
+  {#- Only add to [''] when supporting older TOFS implementations #}
+  {%- for path_prefix_ext in [''] %}
+    {%- set path_prefix_inc_ext = path_prefix ~ path_prefix_ext %}
+    {#- For older TOFS implementation, use `files_switch` from the pillar #}
+    {#- Use the default, new method otherwise #}
+    {%- set fsl = salt['pillar.get'](
+        topdir ~ path_prefix_ext|replace('/', ':') ~ ':files_switch',
+        files_switch_list
+    ) %}
+    {#- Append an empty value to evaluate as `default` in the loop below #}
+    {%- if '' not in fsl %}
+      {%- do fsl.append('') %}
+    {%- endif %}
+    {%- for fs in fsl %}
+      {%- for file in files %}
+        {%- if fs %}
+          {%- set fs_dir = salt['config.get'](fs, fs) %}
+        {%- else %}
+          {%- set fs_dir = salt['config.get'](topdir ~ ':tofs:dirs:default', 'default') %}
+        {%- endif %}
+        {%- set url = '- salt://' ~ '/'.join([
+            path_prefix_inc_ext,
+            files_dir,
+            fs_dir,
+            file.lstrip('/')
+        ]) %}
 {{ url | indent(indent_width, true) }}
+      {%- endfor %}
     {%- endfor %}
   {%- endfor %}
-    {%- for file in files %}
-      {%- set url = '- salt://' ~ '/'.join([path_prefix,
-                                            'files/default',
-                                            file.lstrip('/')]) %}
-{{ url | indent(indent_width, true) }}
-    {%- endfor %}
 {%- endmacro %}


### PR DESCRIPTION
* As discussed between comments:
  - https://freenode.logbot.info/saltstack-formulas/20190214#c1995273
  - https://freenode.logbot.info/saltstack-formulas/20190214#c1995487

---

I'll explain this inline and in further comments.

---

- [x] `prefix` removed -- ultimately replaced by `tpldir` to make `files_switch` macro fully-portable.
    - [x] Potential bug: Confirm that this works properly in `macros.jinja` when using the `{% from ... %}` directive from an `.sls` file in a nested directory (e.g. `pkg/install.sls`).
- [x] `path_prefix` configurable.
- [x] `files_dir` configurable.
- [x] `files_switch_list` configurable.
- [x] `default` configurable.
- [x] `files_switch` pillar values extended beyond searching for grains only -- allowing any number of custom paths to be defined (evaluated as literal paths).
- [x] Duplication removed (single `for` loop in `files_switch`).
- [x] Update `pillar.example` -- current scheme (working with existing formulas using TOFS).
- [x] Update `pillar.example` -- proposed scheme (improved layout with minor change required to existing formulas using TOFS).
- [x] Pillar structure resolved (discussion required) -- see [comment](https://github.com/saltstack-formulas/template-formula/pull/28#issuecomment-463911059) below.
    * PR is based on the proposed `pillar.example` scheme.
- [ ] Update all documentation and inline comments as required.
- [x] Check and update tests to ensure they are passing.