### PR TITLE
Fix missing ')'

### DIFF
--- a/template/config.sls
+++ b/template/config.sls
@@ -10,7 +10,7 @@ include:
 template-config:
   file.managed:
     - name: {{ template.config }}
-    - source: {{ files_switch('template', ['example.tmpl'] }}
+    - source: {{ files_switch('template', ['example.tmpl']) }}
     - mode: 644
     - user: root
     - group: root


### PR DESCRIPTION
       local:
           Data failed to compile:
       ----------
           Rendering SLS 'base:template.config' failed: Jinja syntax error: unexpected '}', expected ')'; line 13

       ---
       [...]
         - template.install

       template-config:
         file.managed:
           - name: {{ template.config }}
           - source: {{ files_switch('template', ['example.tmpl'] }}    <======================
           - mode: 644
           - user: root
           - group: root
       ---
