### PR TITLE
Add a testing scaffold with `kitchen-ci`, `inspec` and `travis` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,103 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a packager
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.kitchen
+.kitchen.local.yml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# For help on this file's format, see https://kitchen.ci/
+driver:
+  name: docker
+
+driver_config:
+  use_sudo: false
+  privileged: true
+  provision_command: mkdir -p /run/sshd
+
+platforms:
+  - name: debian-9
+    driver_config:
+      # This run_command is required to test systemd services in docker
+      run_command: /lib/systemd/systemd
+      provision_command:
+        - apt-get install udev -y
+  - name: ubuntu-18.04
+    driver_config:
+      run_command: /lib/systemd/systemd
+      provision_command:
+        - apt-get install udev -y
+  - name: centos-7
+    driver_config:
+      image: centos:7
+      run_command: /usr/lib/systemd/systemd
+
+provisioner:
+  name: salt_solo
+  log_level: debug
+  require_chef: false
+  salt_version: latest
+  formula: template
+  salt_copy_filter:
+    - .kitchen
+    - .git
+  pillars-from-files:
+    template.sls: pillar.example
+  pillars:
+    top.sls:
+      base:
+        '*':
+          - template
+  state_top:
+    base:
+      '*':
+        - template
+
+verifier:
+  # https://www.inspec.io/
+  name: inspec
+  sudo: true
+  # cli, documentation, html, progress, json, json-min, json-rspec, junit
+  reporter:
+    - cli
+  inspec_tests:
+    - path: test/integration/default
+
+suites:
+  - name: default
+  # Below is an example where test suites are segregated by os_family
+  # - name: debian
+  #   excludes:
+  #     - centos-7
+  # - name: redhat
+  #   excludes:
+  #     - debian-9
+  #     - ubuntu-18.04
+  #   provisioner:
+  #     # You can add dependencies on other formulas to set up this formula's environment
+  #     dependencies:
+  #       - name: epel
+  #         repo: git
+  #         source: https://github.com/saltstack-formulas/epel-formula.git
+  #     state_top:
+  #       base:
+  #         '*':
+  #           - epel
+  #           - template
+  #     pillars:
+  #       top.sls:
+  #         base:
+  #           '*':
+  #           - epel
+  #           - template
+  #       epel.sls:
+  #         disabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+cache: bundler
+language: ruby
+
+services:
+  - docker
+
+before_install:
+  - bundle install
+
+env:
+  matrix:
+    - INSTANCE: default-debian-9
+    - INSTANCE: default-ubuntu-1804
+    - INSTANCE: default-centos-7
+
+script:
+  - bundle exec kitchen verify ${INSTANCE}
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+v0.2.0 (2019-02-17)
+-------------------
+- Added a working testing scaffold and travis support. [Javier Bértoli]
 
 v0.1.7 (2019-02-16)
 -------------------

--- a/FORMULA
+++ b/FORMULA
@@ -1,7 +1,7 @@
 name: template
 os: Debian, Ubuntu, Raspbian, RedHat, Fedora, CentOS, Suse, openSUSE, Gentoo, Funtoo, Arch, Manjaro, Alpine, FreeBSD, OpenBSD, Solaris, SmartOS, Windows, MacOS
 os_family: Debian, RedHat, Suse, Gentoo, Arch, Alpine, FreeBSD, OpenBSD, Solaris, Windows, MacOS
-version: 0.1.5
+version: 0.2.0
 release: 1
 minimum_version: 2016.11
 summary: Template formula

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "test-kitchen"
+gem "kitchen-docker"
+gem "kitchen-salt"
+gem "kitchen-inspec"
+

--- a/pillar.example
+++ b/pillar.example
@@ -5,9 +5,34 @@ template:
   lookup:
     master: template-master
 
-  # The files_switch key serves as a selector for alternative
-  # directories under the formula files directory. See TOFS pattern
-  # doc for more info.
-  files_switch:
-    - id
-    - os_familly
+  # Using bash package and udev service as an example. This allows us to
+  # test the template formula itself. You should set these parameters to
+  # examples that make sense in the contexto of the formula you're writing.
+  pkg: bash
+  config: /etc/template-formula.conf
+  service:
+    name: systemd-udevd
+
+  tofs:
+    # The files_switch key serves as a selector for alternative
+    # directories under the formula files directory. See TOFS pattern
+    # doc for more info.
+    # Note: Any value not evaluated by `config.get` will be used literally.
+    # This can be used to set custom paths, as many levels deep as required.
+    files_switch:
+      - any/path/can/be/used/here
+      - id
+      - osfinger
+      - os
+      - os_familly
+    # All aspects of path/file resolution are customisable using the options below.
+    # This is unnecessary in most cases; there are sensible defaults.
+    # path_prefix: template_alt
+    # dirs:
+    #   files: files_alt
+    #   default: default_alt
+    # files:
+    #   template-config:
+    #     - 'example_alt.tmpl'
+    #     - 'example_alt.tmpl.jinja'
+

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -1,0 +1,11 @@
+control 'Template configuration' do
+  title 'should match desired lines'
+
+  describe file('/etc/template-formula.conf') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    its('mode') { should cmp '0644' }
+    its('content') { should include 'This is an example file from SaltStack template-formula.' }
+  end
+end

--- a/test/integration/default/controls/packages_spec.rb
+++ b/test/integration/default/controls/packages_spec.rb
@@ -1,0 +1,7 @@
+control 'Template package' do
+  title 'should be installed'
+
+  describe package('bash') do
+    it { should be_installed }
+  end
+end

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -1,0 +1,9 @@
+control 'Template service' do
+  impact 0.5
+  title 'should be running and enabled'
+
+  describe service('systemd-udevd') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,11 +1,8 @@
 name: template
 title: Template Formula
 maintainer: Your Name
-copyright: Your Name
-copyright_email: your.email@example.com
 license: Apache-2.0
 summary: Verify that the template formula is setup and configured correctly
-version: 0.1.0
 supports:
   - os-name: debian
     release: 9.5

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,0 +1,15 @@
+name: template
+title: Template Formula
+maintainer: Your Name
+copyright: Your Name
+copyright_email: your.email@example.com
+license: Apache-2.0
+summary: Verify that the template formula is setup and configured correctly
+version: 0.1.0
+supports:
+  - os-name: debian
+    release: 9.5
+  - os-name: centos
+    release: 7.6.1810
+  - os-name: ubuntu
+    release: 18.04

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -5,8 +5,5 @@ license: Apache-2.0
 summary: Verify that the template formula is setup and configured correctly
 supports:
   - os-name: debian
-    release: 9.5
   - os-name: centos
-    release: 7.6.1810
   - os-name: ubuntu
-    release: 18.04


### PR DESCRIPTION
The template can be tested, it's using `pkg: bash` and `service:name: systemd-udevd` in `pillar.example`