### PR TITLE
feat(kitchen+travis): conduct tests on a wider range of platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - INSTANCE: default-centos-7
     # - INSTANCE: default-centos-6
     - INSTANCE: default-fedora
-    # - INSTANCE: default-opensuse-leap
+    - INSTANCE: default-opensuse-leap
 
 script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,18 @@ services:
 before_install:
   - bundle install
 
+# Make sure the instances listed below match up with
+# the `platforms` defined in `kitchen.yml`
 env:
   matrix:
     - INSTANCE: default-debian-9
+    - INSTANCE: default-debian-8
     - INSTANCE: default-ubuntu-1804
+    - INSTANCE: default-ubuntu-1604
     - INSTANCE: default-centos-7
+    # - INSTANCE: default-centos-6
+    - INSTANCE: default-fedora
+    # - INSTANCE: default-opensuse-leap
 
 script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,22 +10,48 @@ driver_config:
   privileged: true
   provision_command: mkdir -p /run/sshd
 
+# Make sure the platforms listed below match up with
+# the `env.matrix` instances defined in `.travis.yml`
 platforms:
   - name: debian-9
     driver_config:
       # This run_command is required to test systemd services in docker
       run_command: /lib/systemd/systemd
       provision_command:
-        - apt-get install udev -y
+        - apt install udev -y
+  - name: debian-8
+    driver_config:
+      run_command: /lib/systemd/systemd
+      provision_command:
+        - apt install udev -y
   - name: ubuntu-18.04
     driver_config:
       run_command: /lib/systemd/systemd
       provision_command:
-        - apt-get install udev -y
+        - apt install udev -y
+  - name: ubuntu-16.04
+    driver_config:
+      run_command: /lib/systemd/systemd
+      provision_command:
+        - apt install udev -y
   - name: centos-7
     driver_config:
       image: centos:7
       run_command: /usr/lib/systemd/systemd
+  # - name: centos-6
+  #   driver_config:
+  #     image: centos:6
+  #     run_command: /usr/lib/systemd/systemd
+  - name: fedora
+    driver_config:
+      image: fedora
+      run_command: /usr/lib/systemd/systemd
+      provision_command:
+        - yum install udev -y
+  # - name: opensuse-leap
+  #   driver_config:
+  #     image: opensuse/leap
+  #     run_command: /usr/lib/systemd/systemd
 
 provisioner:
   name: salt_solo

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,27 +13,28 @@ driver_config:
 # Make sure the platforms listed below match up with
 # the `env.matrix` instances defined in `.travis.yml`
 platforms:
+  # The `run_command` used for each platform is required to
+  # test `systemd` services in docker
   - name: debian-9
     driver_config:
-      # This run_command is required to test systemd services in docker
       run_command: /lib/systemd/systemd
       provision_command:
-        - apt install udev -y
+        - apt install -y udev
   - name: debian-8
     driver_config:
       run_command: /lib/systemd/systemd
       provision_command:
-        - apt install udev -y
+        - apt install -y udev
   - name: ubuntu-18.04
     driver_config:
       run_command: /lib/systemd/systemd
       provision_command:
-        - apt install udev -y
+        - apt install -y udev
   - name: ubuntu-16.04
     driver_config:
       run_command: /lib/systemd/systemd
       provision_command:
-        - apt install udev -y
+        - apt install -y udev
   - name: centos-7
     driver_config:
       image: centos:7
@@ -44,14 +45,16 @@ platforms:
   #     run_command: /usr/lib/systemd/systemd
   - name: fedora
     driver_config:
-      image: fedora
       run_command: /usr/lib/systemd/systemd
       provision_command:
-        - yum install udev -y
-  # - name: opensuse-leap
-  #   driver_config:
-  #     image: opensuse/leap
-  #     run_command: /usr/lib/systemd/systemd
+        - yum install -y udev
+  - name: opensuse-leap
+    driver_config:
+      image: opensuse/leap
+      run_command: /usr/lib/systemd/systemd
+      provision_command:
+        - zypper install -y udev
+        - systemctl enable sshd.service
 
 provisioner:
   name: salt_solo

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -5,5 +5,7 @@ license: Apache-2.0
 summary: Verify that the template formula is setup and configured correctly
 supports:
   - os-name: debian
-  - os-name: centos
   - os-name: ubuntu
+  - os-name: centos
+  - os-name: fedora
+  - os-name: opensuse


### PR DESCRIPTION
Based on discussions Slack/IRC/Matrix leading to [the following plan](https://freenode.logbot.info/saltstack-formulas/20190220#c2012702):

* Debian:
  - debian-9
  - debian-8
  - ubuntu-18
  - ubuntu-16
* RedHat:
  - centos-7
  - centos-6
  - fedora
* Suse:
  - opensuse

---

WIP because 6/8 are working (the other two have been commented out for now), so need to work out how we want to proceed.