### PR TITLE
ci(travis): include `commitlint` stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ env:
 script:
   - bundle exec kitchen verify ${INSTANCE}
 
-before_deploy:
-  # Only deploy if the build passed successfully
-  - test $TRAVIS_TEST_RESULT = 0
-
 jobs:
   include:
     # Define the commitlint stage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+stages:
+  - test
+  - commitlint
+  - name: release
+    if: branch = master
+
 sudo: required
 cache: bundler
 language: ruby
@@ -22,9 +28,16 @@ before_deploy:
   - test $TRAVIS_TEST_RESULT = 0
 
 jobs:
-  # Only run if this is the `master` branch
-  if: branch = master
   include:
+    # Define the commitlint stage
+    - stage: commitlint
+      language: node_js
+      node_js: lts/*
+      before_install: skip
+      script:
+        - npm install @commitlint/config-conventional -D
+        - npm install @commitlint/travis-cli -D
+        - commitlint-travis
     # Define the release stage that runs semantic-release
     - stage: release
       language: node_js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 ## Commit message formatting
 
+### Automation of multiple processes
+
 This repo uses [`semantic-release`](https://github.com/semantic-release/semantic-release) for automating numerous processes such as bumping the version number appropriately, creating new tags/releases and updating the changelog.
 The entire process relies on the structure of commit messages to determine the version bump, which is then used for the rest of the automation.
 
@@ -24,6 +26,15 @@ So based on the example above:
 * The `type` translates into a `Documentation` sub-heading.
 * The `(scope):` will be shown in bold text without the brackets.
 * The `subject` follows the `scope` as standard text.
+
+### Linting commit messages in Travis CI
+
+This repo uses [`commitlint`](https://github.com/conventional-changelog/commitlint) for checking commit messages during CI testing.
+This ensures that they are in accordance with the `semantic-release` settings.
+
+For more details about the default settings, refer back to the `commitlint` [reference rules](https://conventional-changelog.github.io/commitlint/#/reference-rules). 
+
+### Relationship between commit type and version bump
 
 This formula applies some customisations to the defaults, as outlined in the table below,
 based upon the [type](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type) of the commit:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+};


### PR DESCRIPTION
* https://github.com/conventional-changelog/commitlint
  - Lint commit messages.
  - Ensure that they are in accordance with `semantic-release` settings.
  - Use Travis CI to display errors and prevent release stage if so.
* https://conventional-changelog.github.io/commitlint/#/reference-rules
  - Specific rules are defined in `commitlint.config.js`.
  - Using the default rules at the time of this commit.
  - This link gives full details on the default values and how to
    provide custom settings.

---

Notes follow in comments below.