### PR TITLE
feat(authors): update automatically alongside `semantic-release`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,12 @@ jobs:
       node_js: lts/*
       before_install: skip
       script:
+        # Update `AUTHORS.md`
+        - export MAINTAINER_TOKEN=${GH_TOKEN}
+        - go get github.com/myii/maintainer
+        - maintainer contributor
+
+        # Install all dependencies required for `semantic-release`
         - npm install @semantic-release/changelog@3 -D
         - npm install @semantic-release/exec@3 -D
         - npm install @semantic-release/git@7 -D
@@ -47,5 +53,6 @@ jobs:
         provider: script
         skip_cleanup: true
         script:
+          # Run `semantic-release`
           - npx semantic-release@15
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ This formula applies some customisations to the defaults, as outlined in the tab
 based upon the [type](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type) of the commit:
 
 Type|Heading|Description|Bump (default)|Bump (custom)
------|-----|-----|-----|-----
+---|---|---|:-:|:-:
 `build`|Build System|Changes related to the build system|–|
 `chore`|–|Changes to the build process or auxiliary tools and libraries such as documentation generation|–|
 `ci`|Continuous Integration|Changes to the continuous integration configuration|–|

--- a/release.config.js
+++ b/release.config.js
@@ -14,7 +14,7 @@ module.exports = {
         prepareCmd: 'sh ./update_FORMULA.sh ${nextRelease.version}',
       }],
       ['@semantic-release/git', {
-        assets: ['CHANGELOG.md', 'FORMULA'],
+        assets: ['*.md', 'FORMULA'],
       }],
       '@semantic-release/github',
   ],


### PR DESCRIPTION
* https://github.com/gaocegege/maintainer
  - The existing `AUTHORS.md` was created manually using this CLI app.
  - This commit automates this process to run during the CI build, as part of the overall `semantic-release` process.
* https://github.com/myii/maintainer
  - Using an enhanced, forked version of this app.
  - The authors are now shown in a table rather than a bulleted list.

---

This PR is effectively complete but I've marked it `WIP` to get some confirmations before merging.  The main issue is the use of the forked version rather than the (unmaintained) upstream version.  To keep things simple, compare the end results for each:

* **Main**: [existing `AUTHORS.md`](https://github.com/saltstack-formulas/template-formula/blob/410acf82a828a9307c28a448d3d6c9a0be3cceee/AUTHORS.md)
* **Fork**: [proposed `AUTHORS.md`](https://github.com/myii/template-formula/blob/2a6b11f9a55ef39d6336a9c21a4792dd447bae1d/AUTHORS.md)

Should the fork be a SaltStack-Formulas repo?  Should it even be used at all?

Beyond that, there's also the question of documentation.  One of the purposes of this file is to help identify the maintainers of each repo.  Is this worth mentioning specifically, say in the `CONTRIBUTING` file?