### PR TITLE
feat(toc): use `markdown-toc` directly to update inline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,12 @@ jobs:
         - go get github.com/myii/maintainer
         - maintainer contributor
 
+        # Update Tables of Content in the relevant `.md` files
+        - npm install markdown-toc -D
+        - markdown-toc -i CONTRIBUTING.md
+        # - markdown-toc -i README.md
+        - markdown-toc -i TOFS_pattern.md
+
         # Install all dependencies required for `semantic-release`
         - npm install @semantic-release/changelog@3 -D
         - npm install @semantic-release/exec@3 -D

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ type(scope): subject
 Besides the version bump, the changelog and release notes are formatted accordingly.
 So based on the example above:
 
-> ### Documentation
+> <h3>Documentation</h3>
 > 
 > * **contributing:** add commit message formatting instructions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # How to contribute
 
+This document will eventually outline all aspects of guidance to make your contributing experience a fruitful and enjoyable one.
+What it already contains is information about _commit message formatting_ and how that directly affects the numerous automated processes that are used for this repo.
+
 <table><tr><th>Table of Contents</th></tr><tr><td>
 <!-- toc -->
 <!-- tocstop -->
@@ -9,7 +12,7 @@
 
 ### Automation of multiple processes
 
-This repo uses [`semantic-release`](https://github.com/semantic-release/semantic-release) for automating numerous processes such as bumping the version number appropriately, creating new tags/releases and updating the changelog.
+This formula uses [`semantic-release`](https://github.com/semantic-release/semantic-release) for automating numerous processes such as bumping the version number appropriately, creating new tags/releases and updating the changelog.
 The entire process relies on the structure of commit messages to determine the version bump, which is then used for the rest of the automation.
 
 Full details are available in the upstream docs regarding the [Angular Commit Message Conventions](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines).
@@ -34,7 +37,7 @@ So based on the example above:
 
 ### Linting commit messages in Travis CI
 
-This repo uses [`commitlint`](https://github.com/conventional-changelog/commitlint) for checking commit messages during CI testing.
+This formula uses [`commitlint`](https://github.com/conventional-changelog/commitlint) for checking commit messages during CI testing.
 This ensures that they are in accordance with the `semantic-release` settings.
 
 For more details about the default settings, refer back to the `commitlint` [reference rules](https://conventional-changelog.github.io/commitlint/#/reference-rules). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # How to contribute
 
+<table><tr><th>Table of Contents</th></tr><tr><td>
+<!-- toc -->
+<!-- tocstop -->
+</td></tr></table>
+
 ## Commit message formatting
 
 ### Automation of multiple processes

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,8 @@ template-formula
 A SaltStack formula that is empty. It has dummy content to help with a quick
 start on a new formula and it serves as a style guide.
 
+.. contents:: **Table of Contents**
+
 **NOTE**
 
 See the full `Salt Formulas installation and usage instructions

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,10 @@ start on a new formula and it serves as a style guide.
 
 .. contents:: **Table of Contents**
 
-**NOTE**
+General notes
+=============
 
-See the full `Salt Formulas installation and usage instructions
+See the full `SaltStack Formulas installation and usage instructions
 <https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
 If you are interested in writing or contributing to formulas, please pay attention to the `Writing Formula Section

--- a/TOFS_pattern.md
+++ b/TOFS_pattern.md
@@ -7,6 +7,11 @@ Modified by Daniel Dehennin <daniel.dehennin@baby-gnu.org>
 
 All that follows is a proposal based on my experience with [Saltstack](http://www.saltstack.com/). The good thing of a piece of software like this is that you can "bend it" to suit your needs in many possible ways, and this is one of them. All the recommendations and thoughts are given "as it is" with no warranty of any type.
 
+<table><tr><th>Table of Contents</th></tr><tr><td>
+<!-- toc -->
+<!-- tocstop -->
+</td></tr></table>
+
 
 ## Usage of values in pillar vs templates in file_roots
 


### PR DESCRIPTION
* https://github.com/jonschlinkert/markdown-toc
  - Generate a markdown TOC (table of contents) for any markdown files.

---

Our Markdown files are quite lengthy, with content still to be added.  Having a TOC is invaluable but manual maintenance is a pain.  Using the available package linked above, the process of maintaining the TOC across all relevant files is automated during the Travis `semantic-release` run.