### PR TITLE
ci(kitchen): use `salt-minion` version of `opensuse` to ensure tests run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - INSTANCE: default-centos-7
     # - INSTANCE: default-centos-6
     - INSTANCE: default-fedora
-    - INSTANCE: default-opensuse-leap
+    - INSTANCE: default-opensuse-leap-salt-minion
 
 script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -48,13 +48,22 @@ platforms:
       run_command: /usr/lib/systemd/systemd
       provision_command:
         - yum install -y udev
-  - name: opensuse-leap
+  # Note, as of February 2019:
+  #   There have been numerous issues with getting `opensuse` to work
+  #   Note: There have been numerous issues with getting `opensuse` to work
+  #     * `opensuse` is deprecated
+  #     * `opensuse/leap` grabs `15.x`, which doesn't run the `inspec` tests
+  #     * `opensuse/tumbleweed` doesn't install `salt-minion`
+  #     * `opensuse/leap:42.3` does work
+  #     * `opensuse/salt-minion` uses `42.3` with `salt-minion` pre-installed
+  - name: opensuse-leap-salt-minion
     driver_config:
-      image: opensuse/leap
+      image: opensuse/salt-minion
       run_command: /usr/lib/systemd/systemd
       provision_command:
         - zypper install -y udev
         - systemctl enable sshd.service
+        - cat /etc/os-release
 
 provisioner:
   name: salt_solo


### PR DESCRIPTION
* The actual `opensuse/leap` image was passing but not running any
  of the `inspec` tests -- it links to version `15.x`
* `salt-minion` is `42.3`