### PR TITLE
refactor(tpldir): use `tpldir` or derivatives to make formula portable

### DIFF
--- a/template/config.sls
+++ b/template/config.sls
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{%- from "template/map.jinja" import template with context %}
-{%- from "template/macros.jinja" import files_switch with context %}
+{%- from tpldir ~ "/map.jinja" import template with context %}
+{%- from tpldir ~ "/macros.jinja" import files_switch with context %}
 
 include:
   - template.install

--- a/template/install.sls
+++ b/template/install.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{% from "template/map.jinja" import template with context %}
+{%- from tpldir ~ "/map.jinja" import template with context %}
 
 template-pkg:
   pkg.installed:

--- a/template/map.jinja
+++ b/template/map.jinja
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
-{## Start imports as ##}
-{% import_yaml 'template/defaults.yaml' as default_settings %}
-{% import_yaml 'template/osfamilymap.yaml' as osfamilymap %}
-{% import_yaml 'template/osmap.yaml' as osmap %}
-{% import_yaml 'template/osfingermap.yaml' as osfingermap %}
+{#- Get the `topdir` from `tpldir` #}
+{%- set topdir = tpldir.split('/')[0] %}
+{#- Start imports as #}
+{%- import_yaml topdir ~ "/defaults.yaml" as default_settings %}
+{%- import_yaml topdir ~ "/osfamilymap.yaml" as osfamilymap %}
+{%- import_yaml topdir ~ "/osmap.yaml" as osmap %}
+{%- import_yaml topdir ~ "/osfingermap.yaml" as osfingermap %}
 
 {% set defaults = salt['grains.filter_by'](default_settings,
     default='template',
@@ -18,5 +20,5 @@
     )
 ) %}
 
-{## Merge the template pillar ##}
+{#- Merge the template pillar #}
 {% set template = salt['pillar.get']('template', default=defaults, merge=True) %}

--- a/template/service.sls
+++ b/template/service.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{% from "template/map.jinja" import template with context %}
+{%- from tpldir ~ "/map.jinja" import template with context %}
 
 include:
   - template.config


### PR DESCRIPTION
* Close #22.

---

Adapted from the introduction in 068a94d (#28):
https://github.com/saltstack-formulas/template-formula/blob/068a94d3a242ec818640205626b011f8e53acf1a/template/macros.jinja#L46