### PR TITLE
ci(travis): prevent `release` stage running for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ stages:
   - test
   - commitlint
   - name: release
-    if: branch = master
+    if: branch = master AND type != pull_request
 
 sudo: required
 cache: bundler


### PR DESCRIPTION
* The `release` stage will always fail due to security reasons:
  - E.g. https://travis-ci.com/saltstack-formulas/template-formula/jobs/180068519#L466.
  - Discussed: https://github.com/saltstack-formulas/template-formula/pull/42#issuecomment-466446324.
* The `release` stage is unnecessary for PRs until the merge to `master`, in any case.