### PR TITLE
fix(tofs): use `tpldir` derivative `topdir` for pillar (config) paths

### DIFF
--- a/template/config.sls
+++ b/template/config.sls
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
+{%- set topdir = tpldir.split('/')[0] %}
 {%- from tpldir ~ "/map.jinja" import template with context %}
 {%- from tpldir ~ "/macros.jinja" import files_switch with context %}
 
@@ -12,7 +13,7 @@ template-config:
     - name: {{ template.config }}
     - source: {{ files_switch(
                     salt['config.get'](
-                        tpldir ~ ':tofs:files:template-config',
+                        topdir ~ ':tofs:files:template-config',
                         ['example.tmpl', 'example.tmpl.jinja']
                     )
               ) }}


### PR DESCRIPTION
* With nested `.sls` files, `tpldir` respectively resolves to:
  - `template/<subdir>`
* Without this fix, only the default value provided is ever used, respectively:
  - `['example.tmpl', 'example.tmpl.jinja']`
* Follows-on from https://github.com/saltstack-formulas/systemd-formula/pull/22