### PR TITLE
ci(kitchen+travis): disable `debian-8` due to `2019.2` installation bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 env:
   matrix:
     - INSTANCE: default-debian-9
-    - INSTANCE: default-debian-8
+    # - INSTANCE: default-debian-8
     - INSTANCE: default-ubuntu-1804
     - INSTANCE: default-ubuntu-1604
     - INSTANCE: default-centos-7

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -20,11 +20,14 @@ platforms:
       run_command: /lib/systemd/systemd
       provision_command:
         - apt install -y udev
-  - name: debian-8
-    driver_config:
-      run_command: /lib/systemd/systemd
-      provision_command:
-        - apt install -y udev
+  # With the release of `2019.2`, `debian-8` is no longer working
+  # Disabling until the following upstream bug has been resolved:
+  #   * https://github.com/saltstack/salt/issues/51808
+  # - name: debian-8
+  #   driver_config:
+  #     run_command: /lib/systemd/systemd
+  #     provision_command:
+  #       - apt install -y udev
   - name: ubuntu-18.04
     driver_config:
       run_command: /lib/systemd/systemd


### PR DESCRIPTION
* https://github.com/saltstack/salt/issues/51808