### PR TITLE
docs(yaml): os*.yaml map files needs at least an empty dict

### DIFF
--- a/template/map.jinja
+++ b/template/map.jinja
@@ -4,10 +4,10 @@
 {#- Get the `topdir` from `tpldir` #}
 {%- set topdir = tpldir.split('/')[0] %}
 {#- Start imports as #}
-{%- import_yaml topdir ~ "/defaults.yaml" as default_settings %}
-{%- import_yaml topdir ~ "/osfamilymap.yaml" as osfamilymap %}
-{%- import_yaml topdir ~ "/osmap.yaml" as osmap %}
-{%- import_yaml topdir ~ "/osfingermap.yaml" as osfingermap %}
+{%- import_yaml topdir ~ "/defaults.yaml" or {} as default_settings %}
+{%- import_yaml topdir ~ "/osfamilymap.yaml" or {} as osfamilymap %}
+{%- import_yaml topdir ~ "/osmap.yaml" or {} as osmap %}
+{%- import_yaml topdir ~ "/osfingermap.yaml" or {} as osfingermap %}
 
 {% set defaults = salt['grains.filter_by'](default_settings,
     default='template',

--- a/template/osfamilymap.yaml
+++ b/template/osfamilymap.yaml
@@ -5,7 +5,9 @@
 # You just need to add the key:values for an `os_family` that differ
 # from `defaults.yaml`.
 # Only add an `os_family` which is/will be supported by the formula
-# (empty `os_family`s do not need to be listed, just added here as an example).
+#
+# This file can be safely removed if you do not need to provide defaults via
+# the `os_family` grain.
 ---
 Debian:
   pkg: template-debian

--- a/template/osfingermap.yaml
+++ b/template/osfingermap.yaml
@@ -5,7 +5,9 @@
 # You just need to add the key:values for an `osfinger` that differ
 # from `defaults.yaml` + `os_family.yaml` + `osmap.yaml`.
 # Only add an `osfinger` which is/will be supported by the formula
-# (empty `osfinger`s do not need to be listed, just added here as an example).
+#
+# This file can be safely removed if you do not need to provide defaults via
+# the `os_finger` grain.
 ---
 # os: Ubuntu
 Ubuntu-18.04:

--- a/template/osmap.yaml
+++ b/template/osmap.yaml
@@ -5,7 +5,9 @@
 # You just need to add the key:values for an `os` that differ
 # from `defaults.yaml` + `os_family.yaml`.
 # Only add an `os` which is/will be supported by the formula
-# (empty `os`es do not need to be listed, just added here as an example).
+#
+# This file can be safely removed if you do not need to provide defaults via
+# the `os` grain.
 ---
 # os_family: Debian
 Ubuntu:


### PR DESCRIPTION
fixes #59 with a little inline comment in specified files.

The alternative would be to document how to remove unused import from map.jinja, but the doc about 'template-formula use' is still to be done, so I prefer to add this little comment meanwhile.