### PR TITLE
ci(kitchen+travis): use `debian:jessie-backports` as `debian-8`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 env:
   matrix:
     - INSTANCE: default-debian-9
-    # - INSTANCE: default-debian-8
+    - INSTANCE: default-debian-8
     - INSTANCE: default-ubuntu-1804
     - INSTANCE: default-ubuntu-1604
     - INSTANCE: default-centos-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 env:
   matrix:
     - INSTANCE: default-debian-9
-    - INSTANCE: default-debian-8
+    - INSTANCE: default-debian-8-backports
     - INSTANCE: default-ubuntu-1804
     - INSTANCE: default-ubuntu-1604
     - INSTANCE: default-centos-7

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,6 +17,7 @@ platforms:
   # test `systemd` services in docker
   - name: debian-9
     driver_config:
+      image: debian:9
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get update && apt-get install -y udev
@@ -28,11 +29,13 @@ platforms:
         - apt-get update && apt-get install -y udev
   - name: ubuntu-18.04
     driver_config:
+      image: ubuntu:18.04
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get update && apt-get install -y udev
   - name: ubuntu-16.04
     driver_config:
+      image: ubuntu:16.04
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get update && apt-get install -y udev
@@ -46,6 +49,7 @@ platforms:
   #     run_command: /usr/lib/systemd/systemd
   - name: fedora
     driver_config:
+      image: fedora
       run_command: /usr/lib/systemd/systemd
       provision_command:
         - yum -y update && yum -y install udev

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -20,14 +20,11 @@ platforms:
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get update && apt-get install -y udev
-  # With the release of `2019.2`, `debian-8` is no longer working
-  # Disabling until the following upstream bug has been resolved:
-  #   * https://github.com/saltstack/salt/issues/51808
-  # - name: debian-8
-  #   driver_config:
-  #     run_command: /lib/systemd/systemd
-  #     provision_command:
-  #       - apt-get update && apt-get install -y udev
+  - name: debian-8
+    driver_config:
+      run_command: /lib/systemd/systemd
+      provision_command:
+        - apt-get update && apt-get install -y udev
   - name: ubuntu-18.04
     driver_config:
       run_command: /lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -20,8 +20,9 @@ platforms:
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get update && apt-get install -y udev
-  - name: debian-8
+  - name: debian-8-backports
     driver_config:
+      image: debian:jessie-backports
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get update && apt-get install -y udev


### PR DESCRIPTION
* Close #50.
* https://github.com/saltstack/salt/issues/51808
* https://github.com/saltstack/salt-pack/issues/657#issuecomment-467932962