### PR TITLE
docs(rtd): use internal link targets at the top of each `.rst` file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,6 @@ jobs:
 
         # Update Tables of Content in the relevant `.md` files
         - npm install markdown-toc -D
-        - markdown-toc -i CONTRIBUTING.md
-        # - markdown-toc -i README.md
         - markdown-toc -i TOFS_pattern.md
 
         # Install all dependencies required for `semantic-release`

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -1,3 +1,5 @@
+.. _contributing:
+
 How to contribute
 =================
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,3 +1,5 @@
+.. _readme:
+
 template-formula
 ================
 
@@ -33,7 +35,7 @@ Contributing to this repo
 
 **Commit message formatting is significant!!**
 
-Please see `CONTRIBUTING <CONTRIBUTING.rst>`_ for more details.
+Please see :ref:`contributing <CONTRIBUTING>` for more details.
 
 
 Available states

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+.. _index:
+
 .. ``template-formula`` documentation master file.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.


### PR DESCRIPTION
* Convert the existing internal link to use `:ref:` instead