### PR TITLE
refactor(kitchen): `pillars-from-files` => `pillars_from_files`

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -77,7 +77,7 @@ provisioner:
   salt_copy_filter:
     - .kitchen
     - .git
-  pillars-from-files:
+  pillars_from_files:
     template.sls: pillar.example
   pillars:
     top.sls:


### PR DESCRIPTION
* https://github.com/saltstack-formulas/packages-formula/pull/50#discussion_r262769817
  - `pillars-from-files` is deprecated in favor of `pillars_from_files`