### PR TITLE
style(map): use `-` for each Jinja block

### DIFF
--- a/template/map.jinja
+++ b/template/map.jinja
@@ -9,7 +9,7 @@
 {%- import_yaml tplroot ~ "/osmap.yaml" or {} as osmap %}
 {%- import_yaml tplroot ~ "/osfingermap.yaml" or {} as osfingermap %}
 
-{% set defaults = salt['grains.filter_by'](default_settings,
+{%- set defaults = salt['grains.filter_by'](default_settings,
     default='template',
     merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
       merge=salt['grains.filter_by'](osmap, grain='os',
@@ -21,4 +21,4 @@
 ) %}
 
 {#- Merge the template pillar #}
-{% set template = salt['pillar.get']('template', default=defaults, merge=True) %}
+{%- set template = salt['pillar.get']('template', default=defaults, merge=True) %}


### PR DESCRIPTION
Got reminded of this when sending the fix for https://github.com/saltstack-formulas/redis-formula/pull/77.  Going to merge since this is the most minor change.