### PR TITLE
 fix(tofs): use `source_files` instead of `files`

### DIFF
--- a/docs/TOFS_pattern.rst
+++ b/docs/TOFS_pattern.rst
@@ -316,7 +316,7 @@ We can simplify the ``conf.sls`` with the new ``files_switch`` macro to use in t
        - template: jinja
        - source: {{ files_switch(
                      salt['config.get'](
-                         tplroot ~ ':tofs:files:Configure NTP',
+                         tplroot ~ ':tofs:source_files:Configure NTP',
                          ['/etc/ntp.conf.jinja']
                      )
                ) }}
@@ -326,7 +326,7 @@ We can simplify the ``conf.sls`` with the new ``files_switch`` macro to use in t
          - pkg: Install NTP package
 
 
-* This uses ``config.get``, searching for ``nfs:tofs:files:Configure NTP`` to determine the list of template files to use.
+* This uses ``config.get``, searching for ``nfs:tofs:source_files:Configure NTP`` to determine the list of template files to use.
 * If this does not yield any results, the default of ``['/etc/ntp.conf.jinja']`` will be used.
 
 In ``macros.jinja``, we define this new macro ``files_switch``.
@@ -417,16 +417,16 @@ Resulting in:
            ...
            - salt://ntp/files/default_alt/etc/ntp.conf.jinja
 
-Customise the list of template ``files``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Customise the list of ``source_files``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The list of template ``files`` can be given:
+The list of ``source_files`` can be given:
 
 .. code-block:: sls
 
    ntp:
      tofs:
-       files:
+       source_files:
          Configure NTP:
            - '/etc/ntp.conf.jinja'
            - '/etc/ntp.conf_alt.jinja'

--- a/pillar.example
+++ b/pillar.example
@@ -31,7 +31,7 @@ template:
     # dirs:
     #   files: files_alt
     #   default: default_alt
-    # files:
+    # source_files:
     #   template-config-file-file-managed:
     #     - 'example_alt.tmpl'
     #     - 'example_alt.tmpl.jinja'

--- a/pillar.example
+++ b/pillar.example
@@ -32,7 +32,7 @@ template:
     #   files: files_alt
     #   default: default_alt
     # files:
-    #   template-config:
+    #   template-config-file-file-managed:
     #     - 'example_alt.tmpl'
     #     - 'example_alt.tmpl.jinja'
 

--- a/template/config/file.sls
+++ b/template/config/file.sls
@@ -15,7 +15,7 @@ template-config-file-file-managed:
     - name: {{ template.config }}
     - source: {{ files_switch(
                     salt['config.get'](
-                        tplroot ~ ':tofs:files:template-config-file-file-managed',
+                        tplroot ~ ':tofs:source_files:template-config-file-file-managed',
                         ['example.tmpl', 'example.tmpl.jinja']
                     )
               ) }}

--- a/template/config/file.sls
+++ b/template/config/file.sls
@@ -15,7 +15,7 @@ template-config-file-file-managed:
     - name: {{ template.config }}
     - source: {{ files_switch(
                     salt['config.get'](
-                        tplroot ~ ':tofs:files:template-config',
+                        tplroot ~ ':tofs:files:template-config-file-file-managed',
                         ['example.tmpl', 'example.tmpl.jinja']
                     )
               ) }}

--- a/template/macros.jinja
+++ b/template/macros.jinja
@@ -1,4 +1,4 @@
-{%- macro files_switch(files,
+{%- macro files_switch(source_files,
                        default_files_switch=['id', 'os_family'],
                        indent_width=6) %}
   {#-
@@ -7,7 +7,7 @@
     Files Switch (TOFS) pattern.
 
     Params:
-      * files: ordered list of files to look for
+      * source_files: ordered list of files to look for
       * default_files_switch: if there's no pillar
         '<tplroot>:tofs:files_switch' this is the ordered list of grains to
         use as selector switch of the directories under
@@ -23,7 +23,7 @@
           - name: /etc/yyy/zzz.conf
           - source: {{ files_switch(
                           salt['config.get'](
-                              tplroot ~ ':tofs:files:Deploy configuration',
+                              tplroot ~ ':tofs:source_files:Deploy configuration',
                               ['/etc/yyy/zzz.conf', '/etc/yyy/zzz.conf.jinja']
                           )
                     ) }}
@@ -66,7 +66,7 @@
       {%- do fsl.append('') %}
     {%- endif %}
     {%- for fs in fsl %}
-      {%- for file in files %}
+      {%- for source_file in source_files %}
         {%- if fs %}
           {%- set fs_dir = salt['config.get'](fs, fs) %}
         {%- else %}
@@ -76,7 +76,7 @@
             path_prefix_inc_ext,
             files_dir,
             fs_dir,
-            file.lstrip('/')
+            source_file.lstrip('/')
         ]) %}
 {{ url | indent(indent_width, true) }}
       {%- endfor %}


### PR DESCRIPTION
* As discussed in the Slack/IRC/Matrix room from this point forward:
  - https://freenode.logbot.info/saltstack-formulas/20190308#c2046753

---

Once agreed upon, changes need to propagated based on recent TOFS updates in other formulas:

* [ ] https://github.com/saltstack-formulas/systemd-formula/pull/17
* [ ] https://github.com/saltstack-formulas/lighttpd-formula/pull/2
* [ ] https://github.com/claudekenni/stack-formula/pull/1

Please add a comment if I have missed anywhere else.

---

Have tested this with a modified `template/config.file.sls`, introducing multiple uses of the `files_switch` macro.  Confirmed that I got the same results before and after these changes:

```sls
template-config-file-file-managed:
  file.managed:
    - name: /etc/template.d/custom-ubuntu.conf
    - source:
      - salt://template/files/ABC/example_alt.tmpl
      - salt://template/files/Debian/example_alt.tmpl
      - salt://template/files/default/example_alt.tmpl
    - mode: 644
    - user: root
    - group: root
    - template: jinja

formula.autofs.config.master:
  file.managed:
    - name: /root/auto.master
    - source:
      - salt://template/files/ABC/auto.master
      - salt://template/files/Debian/auto.master
      - salt://template/files/default/auto.master
    - mode: 644
    - user: root
    - group: root
    - template: jinja

formula.autofs.config.home:
  file.managed:
    - name: /root/auto.homeLdap
    - source:
      - salt://template/files/ABC/auto.homeLdap
      - salt://template/files/Debian/auto.homeLdap
      - salt://template/files/default/auto.homeLdap
    - mode: 644
    - user: root
    - group: root
    - template: jinja

formula.autofs.config.away:
  file.managed:
    - name: /root/auto.awayLdap
    - source:
      - salt://template/files/ABC/auto.awayLdap
      - salt://template/files/Debian/auto.awayLdap
      - salt://template/files/default/auto.awayLdap
    - mode: 644
    - user: root
    - group: root
    - template: jinja
```