### PR TITLE
refactor(tofs): avoid using “salt['config.get']” for formula writers

### DIFF
--- a/docs/TOFS_pattern.rst
+++ b/docs/TOFS_pattern.rst
@@ -314,12 +314,10 @@ We can simplify the ``conf.sls`` with the new ``files_switch`` macro to use in t
      file.managed:
        - name: {{ ntp.config }}
        - template: jinja
-       - source: {{ files_switch(
-                     salt['config.get'](
-                         tplroot ~ ':tofs:source_files:Configure NTP',
-                         ['/etc/ntp.conf.jinja']
-                     )
-               ) }}
+       - source: {{ files_switch(['/etc/ntp.conf.jinja'],
+                                 lookup='Configure NTP'
+                    )
+                 }}
        - watch_in:
          - service: Enable and start NTP service
        - require:

--- a/template/config/file.sls
+++ b/template/config/file.sls
@@ -13,12 +13,10 @@ include:
 template-config-file-file-managed:
   file.managed:
     - name: {{ template.config }}
-    - source: {{ files_switch(
-                    salt['config.get'](
-                        tplroot ~ ':tofs:source_files:template-config-file-file-managed',
-                        ['example.tmpl', 'example.tmpl.jinja']
-                    )
-              ) }}
+    - source: {{ files_switch(['example.tmpl', 'example.tmpl.jinja'],
+                              lookup='template-config-file-file-managed'
+                 )
+              }}
     - mode: 644
     - user: root
     - group: root

--- a/template/macros.jinja
+++ b/template/macros.jinja
@@ -1,4 +1,5 @@
 {%- macro files_switch(source_files,
+                       lookup=None,
                        default_files_switch=['id', 'os_family'],
                        indent_width=6) %}
   {#-
@@ -8,6 +9,8 @@
 
     Params:
       * source_files: ordered list of files to look for
+      * lookup: key under '<tplroot>:tofs:source_files' to override
+        list of source files
       * default_files_switch: if there's no pillar
         '<tplroot>:tofs:files_switch' this is the ordered list of grains to
         use as selector switch of the directories under
@@ -21,11 +24,8 @@
       Deploy configuration:
         file.managed:
           - name: /etc/yyy/zzz.conf
-          - source: {{ files_switch(
-                          salt['config.get'](
-                              tplroot ~ ':tofs:source_files:Deploy configuration',
-                              ['/etc/yyy/zzz.conf', '/etc/yyy/zzz.conf.jinja']
-                          )
+          - source: {{ files_switch(['/etc/yyy/zzz.conf', '/etc/yyy/zzz.conf.jinja'],
+                                    lookup='Deploy configuration'
                     ) }}
           - template: jinja
 
@@ -52,6 +52,11 @@
       tplroot ~ ':tofs:files_switch',
       default_files_switch
   ) %}
+  {#- Lookup files or fallback to source_files parameter #}
+  {%- set src_files = salt['config.get'](
+      tplroot ~ ':tofs:source_files:' ~ lookup,
+      source_files
+  ) %}
   {#- Only add to [''] when supporting older TOFS implementations #}
   {%- for path_prefix_ext in [''] %}
     {%- set path_prefix_inc_ext = path_prefix ~ path_prefix_ext %}
@@ -66,7 +71,7 @@
       {%- do fsl.append('') %}
     {%- endif %}
     {%- for fs in fsl %}
-      {%- for source_file in source_files %}
+      {%- for src_file in src_files %}
         {%- if fs %}
           {%- set fs_dir = salt['config.get'](fs, fs) %}
         {%- else %}
@@ -76,7 +81,7 @@
             path_prefix_inc_ext,
             files_dir,
             fs_dir,
-            source_file.lstrip('/')
+            src_file.lstrip('/')
         ]) %}
 {{ url | indent(indent_width, true) }}
       {%- endfor %}


### PR DESCRIPTION
We can hide the call to “salt['config.get']” in the macro by only
asking for a namespace where to lookup the “source_files”.

* docs/TOFS_pattern.rst (Example): document the use of the new
  “namespace” parameter.

* template/macros.jinja: add a new “namespace” parameter.
  Lookup files override under
  “<tplroot>:tofs:sources_files:<namespace>” and fallback to
  “source_files” parameter.

* template/config/file.sls (template-config-file-file-managed): use
  the new “namespace” parameter