### PR TITLE
docs(tofs): incorrect path for “source_files” lookup key

### DIFF
--- a/docs/TOFS_pattern.rst
+++ b/docs/TOFS_pattern.rst
@@ -326,7 +326,7 @@ We can simplify the ``conf.sls`` with the new ``files_switch`` macro to use in t
          - pkg: Install NTP package
 
 
-* This uses ``config.get``, searching for ``nfs:tofs:source_files:Configure NTP`` to determine the list of template files to use.
+* This uses ``config.get``, searching for ``ntp:tofs:source_files:Configure NTP`` to determine the list of template files to use.
 * If this does not yield any results, the default of ``['/etc/ntp.conf.jinja']`` will be used.
 
 In ``macros.jinja``, we define this new macro ``files_switch``.


### PR DESCRIPTION
* docs/TOFS_pattern.rst: rename “nfs” to “ntp”.