### PR TITLE
fix(travis): use version numbers in Gemfile to prevent failed builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
-gem "test-kitchen"
-gem "kitchen-docker"
-gem "kitchen-salt"
-gem "kitchen-inspec"
+gem 'kitchen-docker', '>= 2.9'
+gem 'kitchen-salt', '>= 0.5.0'
+gem 'kitchen-inspec', '>= 1.1'
 


### PR DESCRIPTION
* `kitchen-salt 0.0.21` being installed instead of current latest `0.5.0`
  - Failing builds since `pillars_from_files` is not recognised
  - Deprecated `pillars-from-files` is working but not the right solution
* Reason: `test-kitchen 2.0.0` was released 3 days ago on March 20, 2019
  - `kitchen-salt 0.5.0` depends on `test-kitchen ~> 1.4`
  - `kitchen-salt 0.0.21` depends on `test-kitchen >= 0`, so gets pulled
* Remove `test-kitchen` since it is pulled automatically by the other gems
  - Allow the correct version to be installed via. dependency resolution

---

More detailed explanation on Slack:

> Found the problem: `Fetching kitchen-salt 0.0.21`.
> 
> The working CI runs: `Fetching kitchen-salt 0.5.0`.
> 
> Due to this, `pillars_from_files` is not recognised and reverting to the deprecated `pillars-from-files` works.  But that's not the solution going forwards.
> 
> Fixing in the `Gemfile`...
> 
> And here's why it started pulling `kitchen-salt 0.0.21` instead of `0.5.0`: `test-kitchen 2.0.0` was released 3 days ago on March 20, 2019.  That version is being pulled by a `Gemfile` without a stipulated version.  But the dependencies of `kitchen-salt` states `test-kitchen ~> 1.4`.  `kitchen-salt 0.0.21` is the "latest" version that "works" with `test-kitchen 2.0.0`, due to its dependency of `test-kitchen >= 0`.