### PR TITLE
revert(kitchen+travis): use `debian:jessie-backports` as `debian-8`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 env:
   matrix:
     - INSTANCE: default-debian-9
-    - INSTANCE: default-debian-8-backports
+    - INSTANCE: default-debian-8
     - INSTANCE: default-ubuntu-1804
     - INSTANCE: default-ubuntu-1604
     - INSTANCE: default-centos-7

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -21,9 +21,9 @@ platforms:
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get update && apt-get install -y udev
-  - name: debian-8-backports
+  - name: debian-8
     driver_config:
-      image: debian:jessie-backports
+      image: debian:8
       run_command: /lib/systemd/systemd
       provision_command:
         - apt-get update && apt-get install -y udev


### PR DESCRIPTION
This reverts commit 1b9d2493c94b4dbeb21ea5e9c6596195cf3ce5cc.

* https://github.com/saltstack/salt-pack/issues/657#issuecomment-474954298
  - `python-systemd` is now available in the SaltStack repo
* Amended the commit to add: `image: debian:8`