### PR TITLE
refactor(tofs): update with latest changes inc. 100% portable `libtofs.jinja`

### DIFF
--- a/template/libtofs.jinja
+++ b/template/libtofs.jinja
@@ -12,13 +12,13 @@
       * source_files: ordered list of files to look for
       * lookup: key under '<tplroot>:tofs:source_files' to override
         list of source files
-      * default_files_switch: if there's no pillar
+      * default_files_switch: if there's no config (e.g. pillar)
         '<tplroot>:tofs:files_switch' this is the ordered list of grains to
         use as selector switch of the directories under
         "<path_prefix>/files"
       * indent_witdh: indentation of the result value to conform to YAML
       * v1_path_prefix: (deprecated) only used for injecting a path prefix into
-        the source, to support older TOFS pillars
+        the source, to support older TOFS configs
 
     Example (based on a `tplroot` of `xxx`):
 
@@ -67,9 +67,9 @@
   {%- endif %}
   {%- for path_prefix_ext in path_prefix_exts %}
     {%- set path_prefix_inc_ext = path_prefix ~ path_prefix_ext %}
-    {#- For older TOFS implementation, use `files_switch` from the pillar #}
+    {#- For older TOFS implementation, use `files_switch` from the config #}
     {#- Use the default, new method otherwise #}
-    {%- set fsl = salt['pillar.get'](
+    {%- set fsl = salt['config.get'](
         tplroot ~ path_prefix_ext|replace('/', ':') ~ ':files_switch',
         files_switch_list
     ) %}

--- a/template/libtofs.jinja
+++ b/template/libtofs.jinja
@@ -55,10 +55,13 @@
       tplroot ~ ':tofs:files_switch',
       default_files_switch
   ) %}
-  {#- Lookup files or fallback to source_files parameter #}
+  {#- Lookup source_files (v2), files (v1), or fallback to source_files parameter #}
   {%- set src_files = salt['config.get'](
       tplroot ~ ':tofs:source_files:' ~ lookup,
-      source_files
+      salt['config.get'](
+          tplroot ~ ':tofs:files:' ~ lookup,
+          source_files
+      )
   ) %}
   {#- Only add to [''] when supporting older TOFS implementations #}
   {%- set path_prefix_exts = [''] %}

--- a/template/libtofs.jinja
+++ b/template/libtofs.jinja
@@ -1,7 +1,8 @@
 {%- macro files_switch(source_files,
                        lookup=None,
                        default_files_switch=['id', 'os_family'],
-                       indent_width=6) %}
+                       indent_width=6,
+                       v1_path_prefix='') %}
   {#-
     Returns a valid value for the "source" parameter of a "file.managed"
     state function. This makes easier the usage of the Template Override and
@@ -16,6 +17,8 @@
         use as selector switch of the directories under
         "<path_prefix>/files"
       * indent_witdh: indentation of the result value to conform to YAML
+      * v1_path_prefix: (deprecated) only used for injecting a path prefix into
+        the source, to support older TOFS pillars
 
     Example (based on a `tplroot` of `xxx`):
 
@@ -58,7 +61,11 @@
       source_files
   ) %}
   {#- Only add to [''] when supporting older TOFS implementations #}
-  {%- for path_prefix_ext in [''] %}
+  {%- set path_prefix_exts = [''] %}
+  {%- if v1_path_prefix != '' %}
+    {%- do path_prefix_exts.append(v1_path_prefix) %}
+  {%- endif %}
+  {%- for path_prefix_ext in path_prefix_exts %}
     {%- set path_prefix_inc_ext = path_prefix ~ path_prefix_ext %}
     {#- For older TOFS implementation, use `files_switch` from the pillar #}
     {#- Use the default, new method otherwise #}


### PR DESCRIPTION
Effectively identical to https://github.com/saltstack-formulas/systemd-formula/pull/27, except that (A) has been provided by merged PR #79.