### PR TITLE
test(saltcheck) Add Basic Saltcheck Tests

### DIFF
--- a/template/saltcheck-tests/init.tst
+++ b/template/saltcheck-tests/init.tst
@@ -1,0 +1,38 @@
+{% for key,value in {
+  'mode': '0644',
+  'user': 'root',
+  'group': 'root',
+}.items() %}
+template-config-file-file-managed-test-{{ key }}:
+  module_and_function: file.get_{{ key }}
+  args:
+    - /etc/template-formula.conf
+  assertion: assertEqual
+  expected-return: '{{ value }}'
+{% endfor %}
+
+template-config-file-file-managed-test-contents:
+  module_and_function: file.search
+  args:
+    - /etc/template-formula.conf
+    - 'This is an example file from SaltStack template-formula.'
+  assertion: assertTrue
+
+template-package-install-pkg-installed-test:
+  module_and_function: pkg.version
+  args:
+    - bash
+  assertion: assertNotEqual
+  expected-return: ''
+
+template-service-running-service-status:
+  module_and_function: service.status
+  args:
+    - systemd-udevd
+  assertion: assertTrue
+
+template-service-running-service-enabled:
+  module_and_function: service.status
+  args:
+    - systemd-udevd
+  assertion: assertTrue


### PR DESCRIPTION
From the recent discussions about Saltcheck, here are some tests.
These should do the same thing as the Inspec Tests

see: https://saltstackcommunity.slack.com/archives/C7LG8SV54/p1554534766188900

One Issue is that Saltcheck does not seem to work with relative paths, importing data from map.jinja throws TemplateNotFound for the yaml files
```
salt.exceptions.SaltRenderError: Jinja error: ./osfamilymap.yaml
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 381, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 2, in top-level template code
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 1033, in make_module
    return TemplateModule(self, self.new_context(vars, shared, locals))
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 1090, in __init__
    self._body_stream = list(template.root_render_func(context))
  File "/var/cache/salt/minion/files/base/template/map.jinja", line 8, in top-level template code
    {%- import_yaml tplroot ~ "/osfamilymap.yaml" or {} as osfamilymap %}
  File "/usr/lib/python2.7/site-packages/salt/utils/jinja.py", line 140, in get_source
    raise TemplateNotFound(template)
TemplateNotFound: ./osfamilymap.yaml
```