### PR TITLE
ci(kitchen+travis): implement new distro-python-salt_version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,20 @@ before_install:
 # the `platforms` defined in `kitchen.yml`
 env:
   matrix:
-    - INSTANCE: default-debian-9
-    - INSTANCE: default-debian-8
-    - INSTANCE: default-ubuntu-1804
-    - INSTANCE: default-ubuntu-1604
-    - INSTANCE: default-centos-7
-    # - INSTANCE: default-centos-6
-    - INSTANCE: default-fedora
-    - INSTANCE: default-opensuse-leap-salt-minion
+    - INSTANCE: v2019-2-py3-debian-9
+    - INSTANCE: v2019-2-py3-ubuntu-1804
+    - INSTANCE: v2019-2-py2-centos-7
+    - INSTANCE: v2019-2-py2-fedora-29
+
+    - INSTANCE: v2018-3-py2-debian-8
+    - INSTANCE: v2018-3-py2-ubuntu-1604
+    # - INSTANCE: v2018-3-py2-bootstrap-centos-6
+    - INSTANCE: v2018-3-py2-forced-version-fedora-28
+    - INSTANCE: v2018-3-py2-opensuse-423
+
+    - INSTANCE: v2017-7-py2-debian-8
+    - INSTANCE: v2017-7-py2-ubuntu-1604
+    # - INSTANCE: v2017-7-py2-bootstrap-centos-6
 
 script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,90 +4,72 @@
 # For help on this file's format, see https://kitchen.ci/
 driver:
   name: docker
-
-driver_config:
   use_sudo: false
   privileged: true
+  run_command: /lib/systemd/systemd
   provision_command: mkdir -p /run/sshd
 
 # Make sure the platforms listed below match up with
 # the `env.matrix` instances defined in `.travis.yml`
 platforms:
-  # The `run_command` used for each platform is required to
-  # test `systemd` services in docker
+  # Latest distros
   - name: debian-9
-    driver_config:
-      image: debian:9
-      run_command: /lib/systemd/systemd
-      provision_command:
-        - apt-get update && apt-get install -y udev
-  - name: debian-8
-    driver_config:
-      image: debian:8
-      run_command: /lib/systemd/systemd
+    driver:
       provision_command:
         - apt-get update && apt-get install -y udev
   - name: ubuntu-18.04
-    driver_config:
-      image: ubuntu:18.04
-      run_command: /lib/systemd/systemd
-      provision_command:
-        - apt-get update && apt-get install -y udev
-  - name: ubuntu-16.04
-    driver_config:
-      image: ubuntu:16.04
-      run_command: /lib/systemd/systemd
+    driver:
       provision_command:
         - apt-get update && apt-get install -y udev
   - name: centos-7
-    driver_config:
-      image: centos:7
-      run_command: /usr/lib/systemd/systemd
-  # - name: centos-6
-  #   driver_config:
-  #     image: centos:6
-  #     run_command: /usr/lib/systemd/systemd
-  - name: fedora
-    driver_config:
-      image: fedora
-      run_command: /usr/lib/systemd/systemd
+  - name: fedora-29
+    driver:
       provision_command:
         - yum -y update && yum -y install udev
-  # As of February 2019, there have been problems getting `opensuse` to work:
-  #   * `opensuse` is deprecated
-  #   * `opensuse/leap` grabs `15.x`, which doesn't run the `inspec` tests
-  #   * `opensuse/tumbleweed` doesn't install `salt-minion`
-  #   * `opensuse/leap:42.3` does work
-  #   * `opensuse/salt-minion` uses `42.3` with `salt-minion` pre-installed
-  - name: opensuse-leap-salt-minion
-    driver_config:
-      image: opensuse/salt-minion
-      run_command: /usr/lib/systemd/systemd
+  - name: opensuse-42.3
+    driver:
       provision_command:
         - zypper refresh && zypper install -y udev
         - systemctl enable sshd.service
-        - cat /etc/os-release
+      run_command: /usr/lib/systemd/systemd
+
+  # Previous distros
+  - name: debian-8
+  - name: ubuntu-16.04
+    driver:
+      provision_command:
+        - apt-get update && apt-get install -y udev
+  - name: fedora-28
+    driver:
+      provision_command:
+        - yum -y update && yum -y install udev
+  # centos-6 guest fails on Debian hosts due to vsyscall issues, see
+  # https://hub.docker.com/_/centos, "A note about vsyscall"
+  # Disabled for `template-formula` because not `systemd` based
+  # - name: centos-6
+  #   driver:
+  #     run_command: /sbin/init
 
 provisioner:
   name: salt_solo
-  log_level: debug
-  require_chef: false
+  log_level: info
   salt_version: latest
+  require_chef: false
   formula: template
   salt_copy_filter:
     - .kitchen
     - .git
-  pillars_from_files:
-    template.sls: pillar.example
+  state_top:
+    base:
+      '*':
+        - template
   pillars:
     top.sls:
       base:
         '*':
           - template
-  state_top:
-    base:
-      '*':
-        - template
+  pillars_from_files:
+    template.sls: pillar.example
 
 verifier:
   # https://www.inspec.io/
@@ -100,31 +82,129 @@ verifier:
     - path: test/integration/default
 
 suites:
-  - name: default
-  # Below is an example where test suites are segregated by os_family
-  # - name: debian
-  #   excludes:
-  #     - centos-7
-  # - name: redhat
-  #   excludes:
-  #     - debian-9
-  #     - ubuntu-18.04
+  # Latest distros, latest salt, python3
+  # These distros have py3 packages available in salt's repo
+  - name: v2019-2-py3
+    includes:
+      - debian-9
+      - ubuntu-18.04
+    provisioner:
+      salt_bootstrap_options: -X -x python3 -d git %s
+      salt_version: '2019.2'
+      pillars:
+        salt.sls:
+          salt:
+            release: '2019.2'
+            py_ver: 'py3'
+    # verifier:
+    #   inspec_tests:
+    #     - path: test/integration/2019-2
+
+  # Latest distros, latest salt, python2
+  # Fedora ships updated py2 versions in their own repos
+  - name: v2019-2-py2
+    includes:
+      - centos-7
+      - fedora-29
+    provisioner:
+      salt_version: '2019.2'
+      pillars:
+        salt.sls:
+          salt:
+            release: '2019.2'
+            py_ver: 'py2'
+    # verifier:
+    #   inspec_tests:
+    #     - path: test/integration/2019-2
+
+  # Previous distros, previous salt, python2
+  - name: v2018-3-py2
+    includes:
+      - debian-8
+      - ubuntu-16.04
+      - opensuse-42.3
+    provisioner:
+      # We require an old version of salt in the provisioner or,
+      # the salt formula fails to downgrade to the desired version to test
+      salt_version: '2018.3'
+      pillars:
+        salt.sls:
+          salt:
+            release: '2018.3'
+            py_ver: 'py2'
+    # verifier:
+    #   inspec_tests:
+    #     - path: test/integration/2018-3
+
+  # # centos-6 ships with python2.6, so it requires extra bootstrapping parameters
+  # # to install python2.7
+  # - name: v2018-3-py2-bootstrap
+  #   includes:
+  #     - centos-6
   #   provisioner:
-  #     # You can add dependencies on other formulas to set up this formula's environment
-  #     dependencies:
-  #       - name: epel
-  #         repo: git
-  #         source: https://github.com/saltstack-formulas/epel-formula.git
-  #     state_top:
-  #       base:
-  #         '*':
-  #           - epel
-  #           - template
+  #     salt_bootstrap_options: -X -d stable %s
+  #     salt_version: '2018.3'
   #     pillars:
-  #       top.sls:
-  #         base:
-  #           '*':
-  #           - epel
-  #           - template
-  #       epel.sls:
-  #         disabled: false
+  #       salt.sls:
+  #         salt:
+  #           release: '2018.3'
+  #           py_ver: 'py2'
+  #   # verifier:
+  #   #   inspec_tests:
+  #   #     - path: test/integration/2018-3
+
+  # To tests fedora 28 & salt v2018.2, we need to force the package version
+  # otherwise the image, which includes the 'updates' repo, will install 2019.2
+  - name: v2018-3-py2-forced-version
+    includes:
+      - fedora-28
+    provisioner:
+      # We require an old version of salt in the provisioner or,
+      # the salt formula fails to downgrade to the desired version to test
+      salt_version: '2018.3'
+      pillars:
+        salt.sls:
+          salt:
+            release: '2018.3'
+            py_ver: 'py2'
+            version: '2018.3.0-1.fc28'
+    # verifier:
+    #   inspec_tests:
+    #     - path: test/integration/2018-3
+
+  # Previous distros, oldest salt, python2
+  - name: v2017-7-py2
+    includes:
+      - debian-8
+      - ubuntu-16.04
+    provisioner:
+      # We require an old version of salt in the provisioner or,
+      # the salt formula fails to downgrade to the desired version to test
+      salt_version: '2017.7'
+      pillars:
+        salt.sls:
+          salt:
+            release: '2017.7'
+            py_ver: 'py2'
+    # verifier:
+    #   inspec_tests:
+    #     - path: test/integration/2017-7
+
+  # # centos-6 ships with python2.6, so it requires extra bootstrapping parameters
+  # # to install python2.7
+  # - name: v2017-7-py2-bootstrap
+  #   includes:
+  #     - centos-6
+  #   provisioner:
+  #     # As centos-6 ships with python2.6, we use the bootstrapper to install python2.7
+  #     salt_bootstrap_options: -X -d stable %s
+  #     salt_version: '2017.7'
+  #     pillars:
+  #       salt.sls:
+  #         salt:
+  #           release: '2017.7'
+  #           py_ver: 'py2'
+  #   # verifier:
+  #   #   inspec_tests:
+  #   #     - path: test/integration/2017-7
+


### PR DESCRIPTION
* Based on: https://github.com/saltstack-formulas/salt-formula/pull/406

---

Merged between the existing setup and the new one linked above.  This paves the way for specific testing to be done by salt version, etc.