### PR TITLE
ci(kitchen): use pre-salted images instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,16 @@ before_install:
 # the `platforms` defined in `kitchen.yml`
 env:
   matrix:
-    - INSTANCE: v2019-2-py3-debian-9
-    - INSTANCE: v2019-2-py3-ubuntu-1804
-    - INSTANCE: v2019-2-py2-centos-7
-    - INSTANCE: v2019-2-py2-fedora-29
-
-    - INSTANCE: v2018-3-py2-debian-8
-    - INSTANCE: v2018-3-py2-ubuntu-1604
-    # - INSTANCE: v2018-3-py2-bootstrap-centos-6
-    - INSTANCE: v2018-3-py2-forced-version-fedora-28
-    - INSTANCE: v2018-3-py2-opensuse-423
-
-    - INSTANCE: v2017-7-py2-debian-8
-    - INSTANCE: v2017-7-py2-ubuntu-1604
-    # - INSTANCE: v2017-7-py2-bootstrap-centos-6
+    - INSTANCE: default-debian-9-2019-2-py3
+    - INSTANCE: default-ubuntu-1804-2019-2-py3
+    - INSTANCE: default-centos-7-2019-2-py2
+    - INSTANCE: default-fedora-29-2019-2-py2
+    - INSTANCE: default-opensuse-423-2018-3-py2
+    - INSTANCE: default-debian-8-2018-3-py2
+    - INSTANCE: default-ubuntu-1604-2018-3-py2
+    - INSTANCE: default-fedora-28-2018-3-py2
+    - INSTANCE: default-debian-8-2017-7-py2
+    - INSTANCE: default-ubuntu-1604-2017-7-py2
 
 script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,53 +7,63 @@ driver:
   use_sudo: false
   privileged: true
   run_command: /lib/systemd/systemd
-  provision_command: mkdir -p /run/sshd
 
 # Make sure the platforms listed below match up with
 # the `env.matrix` instances defined in `.travis.yml`
 platforms:
-  # Latest distros
-  - name: debian-9
+  ## SALT 2019.2
+  - name: debian-9-2019-2-py3
     driver:
-      provision_command:
-        - apt-get update && apt-get install -y udev
-  - name: ubuntu-18.04
+      image: netmanagers/salt-2019.2-py3:debian-9
+  - name: ubuntu-1804-2019-2-py3
     driver:
-      provision_command:
-        - apt-get update && apt-get install -y udev
-  - name: centos-7
-  - name: fedora-29
+      image: netmanagers/salt-2019.2-py3:ubuntu-1804
+  - name: centos-7-2019-2-py2
     driver:
-      provision_command:
-        - yum -y update && yum -y install udev
-  - name: opensuse-42.3
+      image: netmanagers/salt-2019.2-py2:centos-7
+  - name: fedora-29-2019-2-py2
     driver:
-      provision_command:
-        - zypper refresh && zypper install -y udev
-        - systemctl enable sshd.service
-      run_command: /usr/lib/systemd/systemd
+      image: netmanagers/salt-2019.2-py2:fedora-29
 
-  # Previous distros
-  - name: debian-8
-  - name: ubuntu-16.04
+  ## SALT 2018.3
+  - name: opensuse-423-2018-3-py2
     driver:
-      provision_command:
-        - apt-get update && apt-get install -y udev
-  - name: fedora-28
+      image: netmanagers/salt-2018.3-py2:opensuse-423
+      run_command: /usr/lib/systemd/systemd
+  - name: debian-8-2018-3-py2
     driver:
-      provision_command:
-        - yum -y update && yum -y install udev
+      image: netmanagers/salt-2018.3-py2:debian-8
+  - name: ubuntu-1604-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:ubuntu-1604
+  - name: fedora-28-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:fedora-28
+
   # centos-6 guest fails on Debian hosts due to vsyscall issues, see
   # https://hub.docker.com/_/centos, "A note about vsyscall"
   # Disabled for `template-formula` because not `systemd` based
-  # - name: centos-6
+  # - name: centos-6-2018-3
   #   driver:
+  #     image: netmanagers/salt-2018.3-py2:centos-6
+  #     run_command: /sbin/init
+
+  ##S SALT 2017.7
+  - name: debian-8-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:debian-8
+  - name: ubuntu-1604-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:ubuntu-1604
+  # - name: centos-6-2017-7
+  #   driver:
+  #     image: netmanagers/salt-2017.7-py2:centos-6
   #     run_command: /sbin/init
 
 provisioner:
   name: salt_solo
   log_level: info
-  salt_version: latest
+  salt_install: none
   require_chef: false
   formula: template
   salt_copy_filter:
@@ -82,129 +92,4 @@ verifier:
     - path: test/integration/default
 
 suites:
-  # Latest distros, latest salt, python3
-  # These distros have py3 packages available in salt's repo
-  - name: v2019-2-py3
-    includes:
-      - debian-9
-      - ubuntu-18.04
-    provisioner:
-      salt_bootstrap_options: -X -x python3 -d git %s
-      salt_version: '2019.2'
-      pillars:
-        salt.sls:
-          salt:
-            release: '2019.2'
-            py_ver: 'py3'
-    # verifier:
-    #   inspec_tests:
-    #     - path: test/integration/2019-2
-
-  # Latest distros, latest salt, python2
-  # Fedora ships updated py2 versions in their own repos
-  - name: v2019-2-py2
-    includes:
-      - centos-7
-      - fedora-29
-    provisioner:
-      salt_version: '2019.2'
-      pillars:
-        salt.sls:
-          salt:
-            release: '2019.2'
-            py_ver: 'py2'
-    # verifier:
-    #   inspec_tests:
-    #     - path: test/integration/2019-2
-
-  # Previous distros, previous salt, python2
-  - name: v2018-3-py2
-    includes:
-      - debian-8
-      - ubuntu-16.04
-      - opensuse-42.3
-    provisioner:
-      # We require an old version of salt in the provisioner or,
-      # the salt formula fails to downgrade to the desired version to test
-      salt_version: '2018.3'
-      pillars:
-        salt.sls:
-          salt:
-            release: '2018.3'
-            py_ver: 'py2'
-    # verifier:
-    #   inspec_tests:
-    #     - path: test/integration/2018-3
-
-  # # centos-6 ships with python2.6, so it requires extra bootstrapping parameters
-  # # to install python2.7
-  # - name: v2018-3-py2-bootstrap
-  #   includes:
-  #     - centos-6
-  #   provisioner:
-  #     salt_bootstrap_options: -X -d stable %s
-  #     salt_version: '2018.3'
-  #     pillars:
-  #       salt.sls:
-  #         salt:
-  #           release: '2018.3'
-  #           py_ver: 'py2'
-  #   # verifier:
-  #   #   inspec_tests:
-  #   #     - path: test/integration/2018-3
-
-  # To tests fedora 28 & salt v2018.2, we need to force the package version
-  # otherwise the image, which includes the 'updates' repo, will install 2019.2
-  - name: v2018-3-py2-forced-version
-    includes:
-      - fedora-28
-    provisioner:
-      # We require an old version of salt in the provisioner or,
-      # the salt formula fails to downgrade to the desired version to test
-      salt_version: '2018.3'
-      pillars:
-        salt.sls:
-          salt:
-            release: '2018.3'
-            py_ver: 'py2'
-            version: '2018.3.0-1.fc28'
-    # verifier:
-    #   inspec_tests:
-    #     - path: test/integration/2018-3
-
-  # Previous distros, oldest salt, python2
-  - name: v2017-7-py2
-    includes:
-      - debian-8
-      - ubuntu-16.04
-    provisioner:
-      # We require an old version of salt in the provisioner or,
-      # the salt formula fails to downgrade to the desired version to test
-      salt_version: '2017.7'
-      pillars:
-        salt.sls:
-          salt:
-            release: '2017.7'
-            py_ver: 'py2'
-    # verifier:
-    #   inspec_tests:
-    #     - path: test/integration/2017-7
-
-  # # centos-6 ships with python2.6, so it requires extra bootstrapping parameters
-  # # to install python2.7
-  # - name: v2017-7-py2-bootstrap
-  #   includes:
-  #     - centos-6
-  #   provisioner:
-  #     # As centos-6 ships with python2.6, we use the bootstrapper to install python2.7
-  #     salt_bootstrap_options: -X -d stable %s
-  #     salt_version: '2017.7'
-  #     pillars:
-  #       salt.sls:
-  #         salt:
-  #           release: '2017.7'
-  #           py_ver: 'py2'
-  #   # verifier:
-  #   #   inspec_tests:
-  #   #     - path: test/integration/2017-7
-
+  - name: default


### PR DESCRIPTION
@javierbertoli has prepared pre-salted images, which run much faster.  This `WIP` PR implements these for CI testing instead.

---

- [x] Confirm this implementation is OK -- updated from @javierbertoli's gist [linked below](https://github.com/saltstack-formulas/template-formula/pull/92#issuecomment-485759607).
- [x] Remove all `udev` installations from `provision_command` once the images have that installed.
- [x] Decide what to do about `centos-6`.