### PR TITLE
fix(comments): explain that at least an empty dict is required

### DIFF
--- a/template/map.jinja
+++ b/template/map.jinja
@@ -4,10 +4,10 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
 {#- Start imports as #}
-{%- import_yaml tplroot ~ "/defaults.yaml" or {} as default_settings %}
-{%- import_yaml tplroot ~ "/osfamilymap.yaml" or {} as osfamilymap %}
-{%- import_yaml tplroot ~ "/osmap.yaml" or {} as osmap %}
-{%- import_yaml tplroot ~ "/osfingermap.yaml" or {} as osfingermap %}
+{%- import_yaml tplroot ~ "/defaults.yaml" as default_settings %}
+{%- import_yaml tplroot ~ "/osfamilymap.yaml" as osfamilymap %}
+{%- import_yaml tplroot ~ "/osmap.yaml" as osmap %}
+{%- import_yaml tplroot ~ "/osfingermap.yaml" as osfingermap %}
 
 {%- set defaults = salt['grains.filter_by'](default_settings,
     default='template',

--- a/template/osfamilymap.yaml
+++ b/template/osfamilymap.yaml
@@ -6,8 +6,9 @@
 # from `defaults.yaml`.
 # Only add an `os_family` which is/will be supported by the formula
 #
-# This file can be safely removed if you do not need to provide defaults via
-# the `os_family` grain.
+# If you do not need to provide defaults via the `os_family` grain,
+# you will need to provide at least an empty dict in this file, e.g.
+# osfamilymap: {}
 ---
 Debian:
   pkg: template-debian

--- a/template/osfingermap.yaml
+++ b/template/osfingermap.yaml
@@ -6,8 +6,9 @@
 # from `defaults.yaml` + `os_family.yaml` + `osmap.yaml`.
 # Only add an `osfinger` which is/will be supported by the formula
 #
-# This file can be safely removed if you do not need to provide defaults via
-# the `os_finger` grain.
+# If you do not need to provide defaults via the `os_finger` grain,
+# you will need to provide at least an empty dict in this file, e.g.
+# osfingermap: {}
 ---
 # os: Ubuntu
 Ubuntu-18.04:

--- a/template/osmap.yaml
+++ b/template/osmap.yaml
@@ -6,8 +6,9 @@
 # from `defaults.yaml` + `os_family.yaml`.
 # Only add an `os` which is/will be supported by the formula
 #
-# This file can be safely removed if you do not need to provide defaults via
-# the `os` grain.
+# If you do not need to provide defaults via the `os` grain,
+# you will need to provide at least an empty dict in this file, e.g.
+# osmap: {}
 ---
 # os_family: Debian
 Ubuntu:


### PR DESCRIPTION
* For all `os*map.yaml` files
* Remove redundant `or {}` from `map.jinja`
* Close #93

---

See main discussion in #93.  Also links back to #59 and #60.