### PR TITLE
refactor(map): use `config.get` instead of `pillar.get`

### DIFF
--- a/template/map.jinja
+++ b/template/map.jinja
@@ -14,11 +14,11 @@
     merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
       merge=salt['grains.filter_by'](osmap, grain='os',
         merge=salt['grains.filter_by'](osfingermap, grain='osfinger',
-          merge=salt['pillar.get']('template:lookup', default={})
+          merge=salt['config.get']('template:lookup', default={})
         )
       )
     )
 ) %}
 
-{#- Merge the template pillar #}
-{%- set template = salt['pillar.get']('template', default=defaults, merge=True) %}
+{#- Merge the template config (e.g. from pillar) #}
+{%- set template = salt['config.get']('template', default=defaults, merge=True) %}


### PR DESCRIPTION
We've had some discussions in Slack/IRC/Matrix about moving on from `pillar.get` to `config.get`.  `libtofs.jinja` is already using the latter.  Selected `WIP` for this PR since this is something to consider across all formulas.  The intention here is to open up the discussion about going forward with this.

CC: @gtmanfred.