### PR TITLE
chore(gitignore): add `kitchen.local.yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 .hypothesis/
 .kitchen
 .kitchen.local.yml
+kitchen.local.yml
 
 # Translations
 *.mo


### PR DESCRIPTION
* Alongside commit: 3860bf9
* Quoting from https://kitchen.ci/docs/getting-started/kitchen-yml/:
  - As of test-kitchen 1.21.0, we now prefer `kitchen.yml` over `.kitchen.yml`.
  - This preference applies to `kitchen.local.yml` as well.
  - This is backward compatible so the dot versions continue to work.