### PR TITLE
ci(kitchen+travis): use latest pre-salted images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,23 @@ env:
   matrix:
     - INSTANCE: default-debian-9-2019-2-py3
     - INSTANCE: default-ubuntu-1804-2019-2-py3
-    - INSTANCE: default-centos-7-2019-2-py2
-    - INSTANCE: default-fedora-29-2019-2-py2
-    - INSTANCE: default-opensuse-423-2018-3-py2
-    - INSTANCE: default-debian-8-2018-3-py2
+    - INSTANCE: default-centos-7-2019-2-py3
+    - INSTANCE: default-fedora-29-2019-2-py3
+    - INSTANCE: default-opensuse-leap-15-2019-2-py3
+    - INSTANCE: default-debian-9-2018-3-py2
     - INSTANCE: default-ubuntu-1604-2018-3-py2
-    - INSTANCE: default-fedora-28-2018-3-py2
+    - INSTANCE: default-centos-7-2018-3-py2
+    - INSTANCE: default-fedora-29-2018-3-py2
+    # TODO: Use this when fixed instead of `opensuse-leap-42`
+    # Ref: https://github.com/netmanagers/salt-image-builder/issues/2
+    # - INSTANCE: default-opensuse-leap-15-2018-3-py2
+    - INSTANCE: default-opensuse-leap-42-2018-3-py2
     - INSTANCE: default-debian-8-2017-7-py2
     - INSTANCE: default-ubuntu-1604-2017-7-py2
+    # TODO: Enable after improving the formula to work with other than `systemd`
+    # - INSTANCE: default-centos-6-2017-7-py2
+    - INSTANCE: default-fedora-28-2017-7-py2
+    - INSTANCE: default-opensuse-leap-42-2017-7-py2
 
 script:
   - bundle exec kitchen verify ${INSTANCE}
@@ -64,4 +73,3 @@ jobs:
         script:
           # Run `semantic-release`
           - npx semantic-release@15
-

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,48 +17,61 @@ platforms:
       image: netmanagers/salt-2019.2-py3:debian-9
   - name: ubuntu-1804-2019-2-py3
     driver:
-      image: netmanagers/salt-2019.2-py3:ubuntu-1804
-  - name: centos-7-2019-2-py2
+      image: netmanagers/salt-2019.2-py3:ubuntu-18.04
+  - name: centos-7-2019-2-py3
     driver:
-      image: netmanagers/salt-2019.2-py2:centos-7
-  - name: fedora-29-2019-2-py2
+      image: netmanagers/salt-2019.2-py3:centos-7
+  - name: fedora-29-2019-2-py3
     driver:
-      image: netmanagers/salt-2019.2-py2:fedora-29
+      image: netmanagers/salt-2019.2-py3:fedora-29
+  - name: opensuse-leap-15-2019-2-py3
+    driver:
+      image: netmanagers/salt-2019.2-py3:opensuse-leap-15
+      run_command: /usr/lib/systemd/systemd
 
   ## SALT 2018.3
-  - name: opensuse-423-2018-3-py2
+  - name: debian-9-2018-3-py2
     driver:
-      image: netmanagers/salt-2018.3-py2:opensuse-423
-      run_command: /usr/lib/systemd/systemd
-  - name: debian-8-2018-3-py2
-    driver:
-      image: netmanagers/salt-2018.3-py2:debian-8
+      image: netmanagers/salt-2018.3-py2:debian-9
   - name: ubuntu-1604-2018-3-py2
     driver:
-      image: netmanagers/salt-2018.3-py2:ubuntu-1604
-  - name: fedora-28-2018-3-py2
+      image: netmanagers/salt-2018.3-py2:ubuntu-16.04
+  - name: centos-7-2018-3-py2
     driver:
-      image: netmanagers/salt-2018.3-py2:fedora-28
-
-  # centos-6 guest fails on Debian hosts due to vsyscall issues, see
-  # https://hub.docker.com/_/centos, "A note about vsyscall"
-  # Disabled for `template-formula` because not `systemd` based
-  # - name: centos-6-2018-3
+      image: netmanagers/salt-2018.3-py2:centos-7
+  - name: fedora-29-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:fedora-29
+  # TODO: Use this when fixed instead of `opensuse-leap-42`
+  # Ref: https://github.com/netmanagers/salt-image-builder/issues/2
+  # - name: opensuse-leap-15-2018-3-py2
   #   driver:
-  #     image: netmanagers/salt-2018.3-py2:centos-6
-  #     run_command: /sbin/init
+  #     image: netmanagers/salt-2018.3-py2:opensuse-leap-15
+  #     run_command: /usr/lib/systemd/systemd
+  - name: opensuse-leap-42-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:opensuse-leap-42
+      run_command: /usr/lib/systemd/systemd
 
-  ##S SALT 2017.7
+  ## SALT 2017.7
   - name: debian-8-2017-7-py2
     driver:
       image: netmanagers/salt-2017.7-py2:debian-8
   - name: ubuntu-1604-2017-7-py2
     driver:
-      image: netmanagers/salt-2017.7-py2:ubuntu-1604
-  # - name: centos-6-2017-7
-  #   driver:
-  #     image: netmanagers/salt-2017.7-py2:centos-6
-  #     run_command: /sbin/init
+      image: netmanagers/salt-2017.7-py2:ubuntu-16.04
+  # TODO: Modify the formula to work for non-`systemd` platforms
+  - name: centos-6-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:centos-6
+      run_options: '--entrypoint /sbin/init'
+  - name: fedora-28-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:fedora-28
+  - name: opensuse-leap-42-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:opensuse-leap-42
+      run_command: /usr/lib/systemd/systemd
 
 provisioner:
   name: salt_solo

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -1,3 +1,7 @@
+# Temporary `if` due to `opensuse-leap-15` bug re: `service`
+if os[:name] == 'suse'
+  puts "[Skip `service`-based tests due to `opensuse-leap-15` detection bug (see https://github.com/inspec/train/issues/377)]"
+else
 control 'Template service' do
   impact 0.5
   title 'should be running and enabled'
@@ -6,4 +10,5 @@ control 'Template service' do
     it { should be_enabled }
     it { should be_running }
   end
+end
 end

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -9,3 +9,4 @@ supports:
   - os-name: centos
   - os-name: fedora
   - os-name: opensuse
+  - os-name: suse


### PR DESCRIPTION
* Add `suse` to `inspec.yml` for `opensuse-leap-15`

---

The pre-salted images have been updated, with more combinations available as well as more goodies!  This is the next step towards attaining a `5 x 3` matrix, which would have each `os` represented three times, for each of the supported salt versions.