### PR TITLE
fix(`map.jinja`): use pillar/config `.get` according to `__cli` option

### DIFF
--- a/template/map.jinja
+++ b/template/map.jinja
@@ -21,4 +21,4 @@
 ) %}
 
 {#- Merge the template config (e.g. from pillar) #}
-{%- set template = salt['config.get']('template', default=defaults, merge=True) %}
+{%- set template = salt['config.get']('template', default=defaults) %}


### PR DESCRIPTION
* Fix 5dc0b86 in #95
  - No option `merge=True` for `config.get`
* ~Use `pillar.get` for `salt-call` (i.e. `salt-ssh`)~
* ~Use `config.get` via. `defaults.merge` otherwise~
  - ~Reintroduce based on 775a930 in #20~

---

Update: The whole method of fixing this changed completely by the [end of this PR](https://github.com/saltstack-formulas/template-formula/pull/102#issuecomment-492684630).

---

Apologies for seeking multiple reviews again but `map.jinja` is the core of our formulas and this is a significant change, merging the map based on the type of minion.  In https://github.com/saltstack-formulas/template-formula/pull/95#issuecomment-488061151, I mentioned that it appeared to be either one or the other:

> 1. Use `config.get` via. `defaults.merge` -- get the benefit but leave `salt-ssh` behind.
> 1. Use `pillar.get` -- works for everyone but limited to pillar only.

But in https://github.com/saltstack-formulas/template-formula/issues/21#issuecomment-488115575, @alxwr mentioned that there was a way around this:

> AFAIR we could work around the `defaults.merge` issue, because we can detect whether `salt` or `salt-ssh` is used. But this is not pretty. :-)

Asked on Slack:

> **Imran Iqbal**
> I've just been informed that there's a way of detecting that `salt-ssh` is being used.  Anyone know how to do that?
> **Imran Iqbal**
> `__cli`?
> **Daniel Wallace**
> that might be correct, but i don’t know if it would have salt-call on the minion side
> @​Gareth J. Greenaway didn’t you have to do something with this for the salt-ssh + vault?
> **Gareth J. Greenaway**
> @​gtmanfred yeah. I think there is something in `__opts__` iirc, possibly `client`

Resulting in this PR, which constructs the map conditionally:

1. `salt-call` (i.e. `salt-ssh`): Use the recent `map.jinja` method of using`pillar.get`.
1. Otherwise (i.e. `salt-minion`): Use `config.get` via. `defaults.merge`.