### PR TITLE
map.jinja: use tplroot

### DIFF
--- a/template/map.jinja
+++ b/template/map.jinja
@@ -10,15 +10,15 @@
 {%- import_yaml tplroot ~ "/osfingermap.yaml" as osfingermap %}
 
 {%- set defaults = salt['grains.filter_by'](default_settings,
-    default='template',
+    default=tplroot,
     merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
       merge=salt['grains.filter_by'](osmap, grain='os',
         merge=salt['grains.filter_by'](osfingermap, grain='osfinger',
-          merge=salt['config.get']('template:lookup', default={})
+          merge=salt['config.get'](tplroot ~ ':lookup', default={})
         )
       )
     )
 ) %}
 
 {#- Merge the template config (e.g. from pillar) #}
-{%- set template = salt['config.get']('template', default=defaults) %}
+{%- set template = salt['config.get'](tplroot, default=defaults) %}


### PR DESCRIPTION
When updating a formula the following should be sufficient:

```
cp template-formula/template/map.jinja my-formula/my/map.jinja
sed -i '/set template =/set my =/' my-formula/my/map.jinja
```

Tested with `salt` and `salt-ssh` on FreeBSD 11.2.

@myii I'm bringing back a useful change you introduced earlier.