### PR TITLE
fix(`map.jinja`): _merge_ defaults and `config.get`

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,9 @@
 template:
   lookup:
     master: template-master
+    # Just for testing purposes
+    winner: lookup
+    added_in_lookup: lookup_value
 
   # Using bash package and udev service as an example. This allows us to
   # test the template formula itself. You should set these parameters to
@@ -42,3 +45,11 @@ template:
     #     - 'example_alt.tmpl'
     #     - 'example_alt.tmpl.jinja'
 
+    # For testing purposes
+    source_files:
+      template-config-file-file-managed:
+        - 'example.tmpl.jinja'
+
+  # Just for testing purposes
+  winner: pillar
+  added_in_pillar: pillar_value

--- a/template/config/file.sls
+++ b/template/config/file.sls
@@ -19,7 +19,9 @@ template-config-file-file-managed:
               }}
     - mode: 644
     - user: root
-    - group: root
+    - group: {{ template.rootgroup }}
     - template: jinja
     - require:
       - sls: {{ sls_package_install }}
+    - context:
+        template: {{ template | json}}

--- a/template/defaults.yaml
+++ b/template/defaults.yaml
@@ -3,6 +3,10 @@
 ---
 template:
   pkg: template
+  rootgroup: root
   config: '/etc/template'
   service:
     name: template
+  # Just here for testing
+  added_in_defaults: defaults_value
+  winner: defaults

--- a/template/files/default/example.tmpl.jinja
+++ b/template/files/default/example.tmpl.jinja
@@ -4,3 +4,8 @@
 ########################################################################
 
 This is another example file from SaltStack template-formula.
+
+# This is here for testing purposes
+{{ template | json }}
+
+winner of the merge: {{ template['winner'] }}

--- a/template/map.jinja
+++ b/template/map.jinja
@@ -9,16 +9,36 @@
 {%- import_yaml tplroot ~ "/osmap.yaml" as osmap %}
 {%- import_yaml tplroot ~ "/osfingermap.yaml" as osfingermap %}
 
-{%- set defaults = salt['grains.filter_by'](default_settings,
-    default=tplroot,
-    merge=salt['grains.filter_by'](osfamilymap, grain='os_family',
-      merge=salt['grains.filter_by'](osmap, grain='os',
-        merge=salt['grains.filter_by'](osfingermap, grain='osfinger',
-          merge=salt['config.get'](tplroot ~ ':lookup', default={})
+{#- Retrieve the config dict only once #}
+{%- set _config = salt['config.get'](tplroot, default={}) %}
+
+{%- set defaults = salt['grains.filter_by'](
+      default_settings,
+      default=tplroot,
+      merge=salt['grains.filter_by'](
+        osfamilymap,
+        grain='os_family',
+        merge=salt['grains.filter_by'](
+          osmap,
+          grain='os',
+          merge=salt['grains.filter_by'](
+            osfingermap,
+            grain='osfinger',
+            merge=salt['grains.filter_by'](
+              _config,
+              default='lookup'
+            )
+          )
         )
       )
     )
-) %}
+ %}
+{%- set config = salt['grains.filter_by'](
+      {'defaults': defaults},
+      default='defaults',
+      merge=_config
+    )
+ %}
 
-{#- Merge the template config (e.g. from pillar) #}
-{%- set template = salt['config.get'](tplroot, default=defaults) %}
+{#- Change to whatever variable name you like #}
+{%- set template = config %}

--- a/template/osfamilymap.yaml
+++ b/template/osfamilymap.yaml
@@ -30,9 +30,11 @@ Arch:
 
 Alpine: {}
 
-FreeBSD: {}
+FreeBSD:
+  rootgroup: wheel
 
-OpenBSD: {}
+OpenBSD:
+  rootgroup: wheel
 
 Solaris: {}
 

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -6,6 +6,16 @@ control 'Template configuration' do
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     its('mode') { should cmp '0644' }
-    its('content') { should include 'This is an example file from SaltStack template-formula.' }
+    its('content') { should include 'This is another example file from SaltStack template-formula.' }
+    its('content') { should include '"added_in_pillar": "pillar_value"' }
+    its('content') { should include '"added_in_defaults": "defaults_value"' }
+    its('content') { should include '"added_in_lookup": "lookup_value"' }
+    its('content') { should include '"config": "/etc/template-formula.conf"' }
+    its('content') { should include '"lookup": {"added_in_lookup": "lookup_value",' }
+    its('content') { should include '"pkg": "' }
+    its('content') { should include '"service": {"name": "' }
+    its('content') { should include '"tofs": {"files_switch": ["any/path/can/be/used/here", "id", "osfinger", "os", "os_family"], "source_files": {"template-config-file-file-managed": ["example.tmpl.jinja"]}' }
+    its('content') { should include '"winner": "pillar"}' }
+    its('content') { should include 'winner of the merge: pillar' }
   end
 end


### PR DESCRIPTION
The merge which was formerly done by `pillar.get(..., merge=True)` has now to be performed by `grains.filter_by`.

Tested on FreeBSD with both `salt` and `salt-ssh`.