### PR TITLE
ci(travis): reduce matrix down to 5/6 instances (ref: #118)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,17 @@ services:
 
 # Make sure the instances listed below match up with
 # the `platforms` defined in `kitchen.yml`
-# NOTE: To minimise disruption across the whole org, only select five instances
-#       to run and leave the rest commented out
-#       The recommended matrix is shown below
-#       Allow `kitchen.yml` to contain all of the platforms, to allow
-#       comprehensive local testing
+# NOTE: Please try to select up to six instances that add some meaningful
+#       testing of the formula's behaviour. If possible, try to refrain from
+#       the classical "chosing all the instances because I want to test on
+#       another/all distro/s" trap: it will just add time to the testing (see
+#       the discussion on #121).  As an example, the set chosen below covers
+#       the most used distros families, systemd and non-systemd and the latest
+#       three supported Saltstack versions with python2 and 3."
+#       As for `kitchen.yml`, that should still contain all of the platforms,
+#       to allow for comprehensive local testing
 #       Ref: https://github.com/saltstack-formulas/template-formula/issues/118
+#       Ref: https://github.com/saltstack-formulas/template-formula/issues/121
 env:
   matrix:
     - INSTANCE: default-debian-9-2019-2-py3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,33 @@ services:
 
 # Make sure the instances listed below match up with
 # the `platforms` defined in `kitchen.yml`
+# NOTE: To minimise disruption across the whole org, only select five instances
+#       to run and leave the rest commented out
+#       The recommended matrix is shown below
+#       Allow `kitchen.yml` to contain all of the platforms, to allow
+#       comprehensive local testing
+#       Ref: https://github.com/saltstack-formulas/template-formula/issues/118
 env:
   matrix:
     - INSTANCE: default-debian-9-2019-2-py3
-    - INSTANCE: default-ubuntu-1804-2019-2-py3
+    # - INSTANCE: default-ubuntu-1804-2019-2-py3
     - INSTANCE: default-centos-7-2019-2-py3
-    - INSTANCE: default-fedora-29-2019-2-py3
+    # - INSTANCE: default-fedora-29-2019-2-py3
     - INSTANCE: default-opensuse-leap-15-2019-2-py3
-    - INSTANCE: default-debian-9-2018-3-py2
+    # - INSTANCE: default-debian-9-2018-3-py2
     - INSTANCE: default-ubuntu-1604-2018-3-py2
-    - INSTANCE: default-centos-7-2018-3-py2
+    # - INSTANCE: default-centos-7-2018-3-py2
     - INSTANCE: default-fedora-29-2018-3-py2
     # TODO: Use this when fixed instead of `opensuse-leap-42`
     # Ref: https://github.com/netmanagers/salt-image-builder/issues/2
     # - INSTANCE: default-opensuse-leap-15-2018-3-py2
-    - INSTANCE: default-opensuse-leap-42-2018-3-py2
-    - INSTANCE: default-debian-8-2017-7-py2
-    - INSTANCE: default-ubuntu-1604-2017-7-py2
+    # - INSTANCE: default-opensuse-leap-42-2018-3-py2
+    # - INSTANCE: default-debian-8-2017-7-py2
+    # - INSTANCE: default-ubuntu-1604-2017-7-py2
     # TODO: Enable after improving the formula to work with other than `systemd`
     - INSTANCE: default-centos-6-2017-7-py2
-    - INSTANCE: default-fedora-28-2017-7-py2
-    - INSTANCE: default-opensuse-leap-42-2017-7-py2
+    # - INSTANCE: default-fedora-28-2017-7-py2
+    # - INSTANCE: default-opensuse-leap-42-2017-7-py2
 
 script:
   - bundle exec kitchen verify ${INSTANCE}


### PR DESCRIPTION
* The selected 5 in a "T"-shaped matrix:
```
  - 2019.2 (py3): debian-9   fedora-29   opensuse-leap-15
  - 2018.3 (py2):           ubuntu-1604
  - 2017.7 (py2):             centos6
```
* Covers each `os`, each Salt version and both Python versions

---

I was going to go for `centos-7` and `fedora-28` instead but `centos-6` is a "special" platform, which always throws up interesting situations (including not being `systemd`-based).