### PR TITLE
docs(readme): add testing requirements section (from `vault-formula`)

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -104,6 +104,21 @@ Testing
 
 Linux testing is done with ``kitchen-salt``.
 
+Requirements
+^^^^^^^^^^^^
+
+* Ruby
+* Docker
+
+.. code-block:: bash
+
+   $ gem install bundler
+   $ bundle install
+   $ bundle exec kitchen test [platform]
+
+Where ``[platform]`` is the platform name defined in ``kitchen.yml``,
+e.g. ``debian-9-2019-2-py3``.
+
 ``kitchen converge``
 ^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
* https://github.com/saltstack-formulas/vault-formula/blob/43dc95d/docs/README.rst#requirements