### PR TITLE
fix(`libtofs`): use `select` to deal with empty strings in path

### DIFF
--- a/template/libtofs.jinja
+++ b/template/libtofs.jinja
@@ -89,10 +89,10 @@
         {%- endif %}
         {%- set url = [
             '- salt:/',
-            path_prefix_inc_ext,
-            files_dir,
-            fs_dir,
-            src_file,
+            path_prefix_inc_ext.strip('/'),
+            files_dir.strip('/'),
+            fs_dir.strip('/'),
+            src_file.strip('/'),
         ] | select | join('/') %}
 {{ url | indent(indent_width, true) }}
       {%- endfor %}

--- a/template/libtofs.jinja
+++ b/template/libtofs.jinja
@@ -87,12 +87,13 @@
         {%- else %}
           {%- set fs_dir = salt['config.get'](tplroot ~ ':tofs:dirs:default', 'default') %}
         {%- endif %}
-        {%- set url = '- salt://' ~ '/'.join([
+        {%- set url = [
+            '- salt:/',
             path_prefix_inc_ext,
             files_dir,
             fs_dir,
-            src_file.lstrip('/')
-        ]) %}
+            src_file,
+        ] | select | join('/') %}
 {{ url | indent(indent_width, true) }}
       {%- endfor %}
     {%- endfor %}


### PR DESCRIPTION
* To prevent path breakage when any of the following settings are used
  in the pillar/config:

```yaml
  tofs:
    path_prefix: ''
    dirs:
      files:     ''
      default:   ''
```

---

This PR is based on some discussions in our Slack/IRC/Matrix room, where @sticky-note has been looking at how TOFS can be introduced to  the `nginx-formula` (leading to https://github.com/saltstack-formulas/nginx-formula/pull/238).  The above pillar was set and led to some breakages, which I will cover in subsequent comments in this PR.

---

Edit by @n-rodriguez: the diff is in the double slash `//` before and after. Great job :+1: 