### PR TITLE
test(`services_spec`): remove temporary `suse` conditional

### DIFF
--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -4,10 +4,6 @@ if os[:name] == 'centos' and os[:release].start_with?('6')
   service_name = 'crond'
 end
 
-# Temporary `if` due to `opensuse-leap-15` bug re: `service`
-if os[:name] == 'suse'
-  puts "[Skip `service`-based tests due to `opensuse-leap-15` detection bug (see https://github.com/inspec/train/issues/377)]"
-else
 control 'Template service' do
   impact 0.5
   title 'should be running and enabled'
@@ -16,5 +12,4 @@ control 'Template service' do
     it { should be_enabled }
     it { should be_running }
   end
-end
 end


### PR DESCRIPTION
* `train` gem has been fixed upstream
  - https://github.com/inspec/train/pull/451
  - https://rubygems.org/gems/train/versions/2.1.7