### PR TITLE
feat(MacOS): Basic package and group handling

### DIFF
--- a/template/config/file.sls
+++ b/template/config/file.sls
@@ -20,6 +20,7 @@ template-config-file-file-managed:
     - mode: 644
     - user: root
     - group: {{ template.rootgroup }}
+    - makedirs: True
     - template: jinja
     - require:
       - sls: {{ sls_package_install }}

--- a/template/osfamilymap.yaml
+++ b/template/osfamilymap.yaml
@@ -10,6 +10,10 @@
 # you will need to provide at least an empty dict in this file, e.g.
 # osfamilymap: {}
 ---
+{%- if grains.os == 'MacOS' %}
+  {% set rootgroup = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
+{%- endif %}
+
 Debian:
   pkg: template-debian
   config: /etc/template.d/custom.conf
@@ -40,4 +44,5 @@ Solaris: {}
 
 Windows: {}
 
-MacOS: {}
+MacOS:
+  rootgroup: {{ rootgroup | d('') }}


### PR DESCRIPTION
This PR is a basic, but not ideal, enhancement for MacOS.

- There is no 'root' group on Darwin
- There is no `user` and `group` grains either (pity).
- The directory `/etc/template` is not created by homebrewed package installs  

