### PR TITLE
feat(jinja): add macros.jinja file to accumulate common macros

### DIFF
--- a/template/jinja/macros.jinja
+++ b/template/jinja/macros.jinja
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+#
+# Collection of common macros
+
+{%- macro format_kwargs(kwarg) %}
+
+  {%- filter indent(4) %}
+    {%- for k, v in kwarg|dictsort() %}
+- {{ k }}: {{ v }}
+    {%- endfor %}
+  {%- endfilter %}
+
+{%- endmacro %}


### PR DESCRIPTION
This PR introduces a 1st revision of a common `jinja/macros.j2` file to gather generic macros.  The first revision includes a `format_kwargs` macro.

**Background:**
The `format_kwargs` macro is generic solution used in two formulas-
- ceph-formula
- postgres-formula

**format_kwargs macro**
This macro makes short work of rendering SLS lists which must be generated by mapping files and the switching of `grains`.

**Use Case**

osfamilymap.yaml
```
Debian:
  pkg:
    repo:
      name: 'deb https://packages.template.org/debian stable main'
      key_url: https://packages.template.org/debian/template.org.key
      file: file: /etc/apt/sources.list.d/template.list
      dist: stable

RedHat:
  pkg:
    repo:
      name: template-cli
      baseurl: https://packages.template.org/redhat
      key_url: https://packages.template.org/redhat/template.org.key
      enabledTrue: 1
```

package/install.sls
```
{%- from tplroot ~ "/jinja/macros.j2" import format_kwargs with context -%}

template-package-repo-managed:
  pkgrepo.managed:
    {{- format_kwargs(template.pkg.repo) }}
    - require_in:
      - pkg: template-package-install-pkg-installed
```
