### PR TITLE
docs(readme): show only one level in table of contents

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -18,6 +18,7 @@ A SaltStack formula that is empty. It has dummy content to help with a quick
 start on a new formula and it serves as a style guide.
 
 .. contents:: **Table of Contents**
+   :depth: 1
 
 General notes
 -------------


### PR DESCRIPTION
This PR makes the table of contents less verbose (depth: 1).

```
Table of Contents

General notes
Contributing to this repo
Available states
Testing
```

The default depth (two) is too verbose for users.  

The list of available states is not impacted by this update.



