### PR TITLE
refactor(naming): reserve 'pkg' as name of packaging dict

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -12,11 +12,13 @@ template:
   # test the template formula itself. You should set these parameters to
   # examples that make sense in the contexto of the formula you're writing.
   {%- if grains.osfinger == 'CentOS-6' %}
-  pkg: cronie
+  pkg:
+    name: cronie
   service:
     name: crond
   {%- else %}
-  pkg: bash
+  pkg:
+    name: bash
   service:
     name: systemd-udevd
   {%- endif %}

--- a/template/defaults.yaml
+++ b/template/defaults.yaml
@@ -2,7 +2,8 @@
 # vim: ft=yaml
 ---
 template:
-  pkg: template
+  pkg:
+    name: template
   rootgroup: root
   config: '/etc/template'
   service:

--- a/template/osfamilymap.yaml
+++ b/template/osfamilymap.yaml
@@ -15,20 +15,24 @@
 {%- endif %}
 
 Debian:
-  pkg: template-debian
+  pkg:
+    name: template-debian
   config: /etc/template.d/custom.conf
 
 RedHat:
-  pkg: template-redhat
+  pkg:
+    name: template-redhat
   config: /etc/template.conf
 
 Suse:
-  pkg: template-suse
+  pkg:
+    name: template-suse
 
 Gentoo: {}
 
 Arch:
-  pkg: template-arch
+  pkg:
+    name: template-arch
   service:
     name: service-arch
 

--- a/template/osfingermap.yaml
+++ b/template/osfingermap.yaml
@@ -16,6 +16,7 @@ Ubuntu-18.04:
 
 # os: CentOS
 CentOS-6:
-  pkg: template-centos-6
+  pkg:
+    name: template-centos-6
   config: /etc/template.d/custom-centos-6.conf
 CentOS-7: {}

--- a/template/osmap.yaml
+++ b/template/osmap.yaml
@@ -12,14 +12,16 @@
 ---
 # os_family: Debian
 Ubuntu:
-  pkg: template-ubuntu
+  pkg:
+    name: template-ubuntu
   config: /etc/template.d/custom-ubuntu.conf
 
 Raspbian: {}
 
 # os_family: RedHat
 Fedora:
-  pkg: template-fedora
+  pkg:
+    name: template-fedora
   service:
     name: service-fedora
 

--- a/template/package/clean.sls
+++ b/template/package/clean.sls
@@ -11,6 +11,6 @@ include:
 
 template-package-clean-pkg-removed:
   pkg.removed:
-    - name: {{ template.pkg }}
+    - name: {{ template.pkg.name }}
     - require:
       - sls: {{ sls_config_clean }}

--- a/template/package/install.sls
+++ b/template/package/install.sls
@@ -7,4 +7,4 @@
 
 template-package-install-pkg-installed:
   pkg.installed:
-    - name: {{ template.pkg }}
+    - name: {{ template.pkg.name }}

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -12,7 +12,7 @@ control 'Template configuration' do
     its('content') { should include '"added_in_lookup": "lookup_value"' }
     its('content') { should include '"config": "/etc/template-formula.conf"' }
     its('content') { should include '"lookup": {"added_in_lookup": "lookup_value",' }
-    its('content') { should include '"pkg": "' }
+    its('content') { should include '"pkg": {"name": "' }
     its('content') { should include '"service": {"name": "' }
     its('content') { should include '"tofs": {"files_switch": ["any/path/can/be/used/here", "id", "osfinger", "os", "os_family"], "source_files": {"template-config-file-file-managed": ["example.tmpl.jinja"]}' }
     its('content') { should include '"winner": "pillar"}' }


### PR DESCRIPTION
prometheus on centos needs a [repo](https://github.com/lest/prometheus-rpm#centos-7) setup.  I've studied how best to incorporate this into this formula and the result is [here](https://github.com/saltstack-formulas/cloudfoundry-formula/tree/master/cloudfoundry/cli/package). My method involved introducing a **pkg** dictionary to collect packaging related details. That provided the model on which to propose handling package repos. The problem is that "pkg" variable is already in use.  
```
pkg: template
```
This PR is to reclaim "pkg" variable as dict. Let me know if you like the approach. 
```
    pkg:
      name: template
      use_upstream_repo: True
      use_upstream_archive: False
      archive: {}
      repo:
        managed: {}
```
The followup PR will be to to add repo support to both template and then prometheus formulas.