### PR TITLE
refactor(string): remove capitalisation from 'template' string

### DIFF
--- a/FORMULA
+++ b/FORMULA
@@ -4,6 +4,6 @@ os_family: Debian, RedHat, Suse, Gentoo, Arch, Alpine, FreeBSD, OpenBSD, Solaris
 version: 2.1.15
 release: 1
 minimum_version: 2016.11
-summary: Template formula
+summary: template formula
 description: Formula to use as a template for other formulas
 top_level_dir: template

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -1,4 +1,4 @@
-control 'Template configuration' do
+control 'template configuration' do
   title 'should match desired lines'
 
   describe file('/etc/template-formula.conf') do

--- a/test/integration/default/controls/packages_spec.rb
+++ b/test/integration/default/controls/packages_spec.rb
@@ -4,7 +4,7 @@ if os[:name] == 'centos' and os[:release].start_with?('6')
   package_name = 'cronie'
 end
 
-control 'Template package' do
+control 'template package' do
   title 'should be installed'
 
   describe package(package_name) do

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -4,7 +4,7 @@ if os[:name] == 'centos' and os[:release].start_with?('6')
   service_name = 'crond'
 end
 
-control 'Template service' do
+control 'template service' do
   impact 0.5
   title 'should be running and enabled'
 

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,5 +1,5 @@
 name: template
-title: Template Formula
+title: template formula
 maintainer: Your Name
 license: Apache-2.0
 summary: Verify that the template formula is setup and configured correctly


### PR DESCRIPTION
For consistency rename "Template" to "template". 
Related to #98 