### PR TITLE
test(inspec): readme for default profile and a fix

### DIFF
--- a/test/integration/default/README.md
+++ b/test/integration/default/README.md
@@ -1,0 +1,50 @@
+# Default InSpec Profile
+
+This shows the implementation of the Default InSpec [profile](https://github.com/inspec/inspec/blob/master/docs/profiles.md).
+
+## Verify a profile
+
+InSpec ships with built-in features to verify a profile structure.
+
+```bash
+$ inspec check default
+Summary
+-------
+Location: default
+Profile: profile
+Controls: 4
+Timestamp: 2019-06-24T23:09:01+00:00
+Valid: true
+
+Errors
+------
+
+Warnings
+--------
+```
+
+## Execute a profile
+
+To run all **supported** controls on a local machine use `inspec exec /path/to/profile`.
+
+```bash
+$ inspec exec default
+..
+
+Finished in 0.0025 seconds (files took 0.12449 seconds to load)
+8 examples, 0 failures
+```
+
+## Execute a specific control from a profile
+
+To run one control from the profile use `inspec exec /path/to/profile --controls name`.
+
+```bash
+$ inspec exec default --controls package
+.
+
+Finished in 0.0025 seconds (files took 0.12449 seconds to load)
+1 examples, 0 failures
+```
+
+See an [example control here](https://github.com/inspec/inspec/blob/master/examples/profile/controls/example.rb).

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -4,9 +4,9 @@ maintainer: Your Name
 license: Apache-2.0
 summary: Verify that the template formula is setup and configured correctly
 supports:
-  - os-name: debian
-  - os-name: ubuntu
-  - os-name: centos
-  - os-name: fedora
-  - os-name: opensuse
-  - os-name: suse
+  - platform-name: debian
+  - platform-name: ubuntu
+  - platform-name: centos
+  - platform-name: fedora
+  - platform-name: opensuse
+  - platform-name: suse


### PR DESCRIPTION
Update default inspec profile structure per guidelines.

> README.md should be used to explain the profile, its scope, and usage

> Use platform-name to restrict on a specific platform name. ... For compatibility we support os-name and os-family. We recommend all users to change os-name to platform-name and os-family to platform-family.

We will see if unit tests pass ;-)