### PR TITLE
ci(kitchen+travis): replace EOL pre-salted images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,26 +30,30 @@ services:
 #       Ref: https://github.com/saltstack-formulas/template-formula/issues/121
 env:
   matrix:
-    - INSTANCE: default-debian-9-develop-py3
+    - INSTANCE: default-debian-10-develop-py3
     # - INSTANCE: default-ubuntu-1804-develop-py3
     # - INSTANCE: default-centos-7-develop-py3
-    # - INSTANCE: default-fedora-29-develop-py3
+    # - INSTANCE: default-fedora-30-develop-py3
     # - INSTANCE: default-opensuse-leap-15-develop-py3
+    # - INSTANCE: default-amazonlinux-2-develop-py2
     # - INSTANCE: default-debian-9-2019-2-py3
     - INSTANCE: default-ubuntu-1804-2019-2-py3
-    - INSTANCE: default-centos-7-2019-2-py3
-    # - INSTANCE: default-fedora-29-2019-2-py3
+    # - INSTANCE: default-centos-7-2019-2-py3
+    # - INSTANCE: default-fedora-30-2019-2-py3
     # - INSTANCE: default-opensuse-leap-15-2019-2-py3
+    - INSTANCE: default-amazonlinux-2-2019-2-py2
     # - INSTANCE: default-debian-9-2018-3-py2
     # - INSTANCE: default-ubuntu-1604-2018-3-py2
     # - INSTANCE: default-centos-7-2018-3-py2
     - INSTANCE: default-fedora-29-2018-3-py2
-    - INSTANCE: default-opensuse-leap-42-2018-3-py2
+    - INSTANCE: default-opensuse-leap-15-2018-3-py2
+    # - INSTANCE: default-amazonlinux-2-2018-3-py2
     # - INSTANCE: default-debian-8-2017-7-py2
     # - INSTANCE: default-ubuntu-1604-2017-7-py2
     - INSTANCE: default-centos-6-2017-7-py2
-    # - INSTANCE: default-fedora-28-2017-7-py2
-    # - INSTANCE: default-opensuse-leap-42-2017-7-py2
+    # - INSTANCE: default-fedora-29-2017-7-py2
+    # - INSTANCE: default-opensuse-leap-15-2017-7-py2
+    # - INSTANCE: default-amazonlinux-2-2017-7-py2
 
 script:
   - bin/kitchen verify ${INSTANCE}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,9 +12,9 @@ driver:
 # the `env.matrix` instances defined in `.travis.yml`
 platforms:
   ## SALT `develop`
-  - name: debian-9-develop-py3
+  - name: debian-10-develop-py3
     driver:
-      image: netmanagers/salt-develop-py3:debian-9
+      image: netmanagers/salt-develop-py3:debian-10
       provision_command:
         - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
         - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
@@ -30,9 +30,9 @@ platforms:
       provision_command:
         - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
         - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
-  - name: fedora-29-develop-py3
+  - name: fedora-30-develop-py3
     driver:
-      image: netmanagers/salt-develop-py3:fedora-29
+      image: netmanagers/salt-develop-py3:fedora-30
       provision_command:
         - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
         - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
@@ -43,6 +43,12 @@ platforms:
         - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
         - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
       run_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2-develop-py2
+    driver:
+      image: netmanagers/salt-develop-py2:amazonlinux-2
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python2 git develop
 
   ## SALT `2019.2`
   - name: debian-9-2019-2-py3
@@ -54,13 +60,16 @@ platforms:
   - name: centos-7-2019-2-py3
     driver:
       image: netmanagers/salt-2019.2-py3:centos-7
-  - name: fedora-29-2019-2-py3
+  - name: fedora-30-2019-2-py3
     driver:
-      image: netmanagers/salt-2019.2-py3:fedora-29
+      image: netmanagers/salt-2019.2-py3:fedora-30
   - name: opensuse-leap-15-2019-2-py3
     driver:
       image: netmanagers/salt-2019.2-py3:opensuse-leap-15
       run_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2-2019-2-py2
+    driver:
+      image: netmanagers/salt-2019.2-py2:amazonlinux-2
 
   ## SALT `2018.3`
   - name: debian-9-2018-3-py2
@@ -75,10 +84,13 @@ platforms:
   - name: fedora-29-2018-3-py2
     driver:
       image: netmanagers/salt-2018.3-py2:fedora-29
-  - name: opensuse-leap-42-2018-3-py2
+  - name: opensuse-leap-15-2018-3-py2
     driver:
-      image: netmanagers/salt-2018.3-py2:opensuse-leap-42
+      image: netmanagers/salt-2018.3-py2:opensuse-leap-15
       run_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:amazonlinux-2
 
   ## SALT `2017.7`
   - name: debian-8-2017-7-py2
@@ -91,13 +103,16 @@ platforms:
     driver:
       image: netmanagers/salt-2017.7-py2:centos-6
       run_command: /sbin/init
-  - name: fedora-28-2017-7-py2
+  - name: fedora-29-2017-7-py2
     driver:
-      image: netmanagers/salt-2017.7-py2:fedora-28
-  - name: opensuse-leap-42-2017-7-py2
+      image: netmanagers/salt-2017.7-py2:fedora-29
+  - name: opensuse-leap-15-2017-7-py2
     driver:
-      image: netmanagers/salt-2017.7-py2:opensuse-leap-42
+      image: netmanagers/salt-2017.7-py2:opensuse-leap-15
       run_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2-2017-7-py2
+    driver:
+      image: netmanagers/salt-2017.7-py2:amazonlinux-2
 
 provisioner:
   name: salt_solo


### PR DESCRIPTION
```
* Fedora:   30 => 29 & 29 => 28 (EOL)
* OpenSuse: 15 => 42 (EOL)
  - Use `dist: xenial` to prevent failures
```