### PR TITLE
fix(formula): update to current oldest supported version of Salt

### DIFF
--- a/FORMULA
+++ b/FORMULA
@@ -3,7 +3,7 @@ os: Debian, Ubuntu, Raspbian, RedHat, Fedora, CentOS, Suse, openSUSE, Gentoo, Fu
 os_family: Debian, RedHat, Suse, Gentoo, Arch, Alpine, FreeBSD, OpenBSD, Solaris, Windows, MacOS
 version: 3.1.1
 release: 1
-minimum_version: 2016.11
+minimum_version: 2017.7
 summary: template formula
 description: Formula to use as a template for other formulas
 top_level_dir: template


### PR DESCRIPTION
* When formula conversions are performed, this line is usually unchanged
* This ensures that these conversions aren't using even older versions by default

---

Noticed this when reviewing https://github.com/saltstack-formulas/dhcpd-formula/pull/31.