### PR TITLE
chore: use `semantic-release` cross-formula standard structure

### DIFF
--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -169,6 +169,7 @@ These formulas are already compatible with semantic-release:
 * `chrony-formula <https://github.com/saltstack-formulas/chrony-formula>`_
 * `collectd-formula <https://github.com/saltstack-formulas/collectd-formula>`_
 * `deepsea-formula <https://github.com/saltstack-formulas/deepsea-formula>`_
+* `dhcpd-formula <https://github.com/saltstack-formulas/dhcpd-formula>`_
 * `fail2ban-formula <https://github.com/saltstack-formulas/fail2ban-formula>`_
 * `golang-formula <https://github.com/saltstack-formulas/golang-formula>`_
 * `grafana-formula <https://github.com/saltstack-formulas/grafana-formula>`_


### PR DESCRIPTION
* Automated using `ssf-formula` (v0.1.0-rc.4)