### PR TITLE
fix(libtofs): avoid using subpath by default

### DIFF
--- a/docs/TOFS_pattern.rst
+++ b/docs/TOFS_pattern.rst
@@ -493,7 +493,8 @@ For example, the following ``formula.component.config`` SLS:
        - mode: 644
        - template: jinja
        - source: {{ files_switch(['formula.conf'],
-                                 lookup='formula'
+                                 lookup='formula',
+                                 use_subpath=True
                     )
                  }}
 

--- a/template/libtofs.jinja
+++ b/template/libtofs.jinja
@@ -2,7 +2,6 @@
                        lookup=None,
                        default_files_switch=['id', 'os_family'],
                        indent_width=6,
-                       v1_path_prefix='',
                        use_subpath=False) %}
   {#-
     Returns a valid value for the "source" parameter of a "file.managed"
@@ -18,8 +17,6 @@
         use as selector switch of the directories under
         "<path_prefix>/files"
       * indent_witdh: indentation of the result value to conform to YAML
-      * v1_path_prefix: (deprecated) only used for injecting a path prefix into
-        the source, to support older TOFS configs
       * use_subpath: defaults to `False` but if set, lookup the source file
         recursively from the current state directory up to `tplroot`
 
@@ -67,9 +64,7 @@
   {%- set src_files = src_files + source_files %}
   {#- Only add to [''] when supporting older TOFS implementations #}
   {%- set path_prefix_exts = [''] %}
-  {%- if v1_path_prefix != '' %}
-    {%- do path_prefix_exts.append(v1_path_prefix) %}
-  {%- elif use_subpath and tplroot != tpldir %}
+  {%- if use_subpath and tplroot != tpldir %}
     {#- Walk directory tree to find {{ files_dir }} #}
     {%- set subpath_parts = tpldir.lstrip(tplroot).lstrip('/').split('/') %}
     {%- for path in subpath_parts %}

--- a/template/libtofs.jinja
+++ b/template/libtofs.jinja
@@ -2,7 +2,8 @@
                        lookup=None,
                        default_files_switch=['id', 'os_family'],
                        indent_width=6,
-                       v1_path_prefix='') %}
+                       v1_path_prefix='',
+                       use_subpath=False) %}
   {#-
     Returns a valid value for the "source" parameter of a "file.managed"
     state function. This makes easier the usage of the Template Override and
@@ -19,6 +20,8 @@
       * indent_witdh: indentation of the result value to conform to YAML
       * v1_path_prefix: (deprecated) only used for injecting a path prefix into
         the source, to support older TOFS configs
+      * use_subpath: defaults to `False` but if set, lookup the source file
+        recursively from the current state directory up to `tplroot`
 
     Example (based on a `tplroot` of `xxx`):
 
@@ -66,7 +69,7 @@
   {%- set path_prefix_exts = [''] %}
   {%- if v1_path_prefix != '' %}
     {%- do path_prefix_exts.append(v1_path_prefix) %}
-  {%- elif tplroot != tpldir %}
+  {%- elif use_subpath and tplroot != tpldir %}
     {#- Walk directory tree to find {{ files_dir }} #}
     {%- set subpath_parts = tpldir.lstrip(tplroot).lstrip('/').split('/') %}
     {%- for path in subpath_parts %}

--- a/template/subcomponent/config/file.sls
+++ b/template/subcomponent/config/file.sls
@@ -14,7 +14,8 @@ template-subcomponent-config-file-file-managed:
   file.managed:
     - name: {{ template.subcomponent.config }}
     - source: {{ files_switch(['subcomponent-example.tmpl'],
-                              lookup='template-subcomponent-config-file-file-managed'
+                              lookup='template-subcomponent-config-file-file-managed',
+                              use_subpath=True
                  )
               }}
     - mode: 644


### PR DESCRIPTION
So there are two TOFS improvements here in two commits.

For the first one:

* Only the `systemd-formula` uses these, so avoid for all other formulas
  - So need to merge this before propagating https://github.com/myii/ssf-formula/pull/3

The second commit (refactor(libtofs): remove deprecated `v1_path_prefix` argument):

* Unused throughout all SaltStack Formulas
  - Effectively superseded by using subpath
  - May as well merge this and have this propagated by https://github.com/myii/ssf-formula/pull/3 as well