### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -50,7 +50,7 @@ env:
     # - INSTANCE: default-amazonlinux-2-2018-3-py2
     # - INSTANCE: default-debian-8-2017-7-py2
     # - INSTANCE: default-ubuntu-1604-2017-7-py2
-    - INSTANCE: default-centos-6-2017-7-py2
+    - INSTANCE: centos6-centos-6-2017-7-py2
     # - INSTANCE: default-fedora-29-2017-7-py2
     # - INSTANCE: default-opensuse-leap-15-2017-7-py2
     # - INSTANCE: default-amazonlinux-2-2017-7-py2
@@ -60,16 +60,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/define_roles.sls test/salt/pillar/centos6.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -134,6 +134,8 @@ verifier:
 
 suites:
   - name: default
+    excludes:
+      - centos-6-2017-7-py2
     provisioner:
       state_top:
         base:
@@ -144,8 +146,30 @@ suites:
           base:
             '*':
               - template
+              - define_roles
       pillars_from_files:
         template.sls: pillar.example
+        define_roles.sls: test/salt/pillar/define_roles.sls
+    verifier:
+      inspec_tests:
+        - path: test/integration/default
+  - name: centos6
+    includes:
+      - centos-6-2017-7-py2
+    provisioner:
+      state_top:
+        base:
+          '*':
+            - template
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - template
+              - define_roles
+      pillars_from_files:
+        template.sls: test/salt/pillar/centos6.sls
+        define_roles.sls: test/salt/pillar/define_roles.sls
     verifier:
       inspec_tests:
         - path: test/integration/default

--- a/template/map.jinja
+++ b/template/map.jinja
@@ -48,3 +48,9 @@
 
 {#- Change **template** to match with your formula's name and then remove this line #}
 {%- set template = config %}
+
+{#- Post-processing for specific non-YAML customisations #}
+{%- if grains.os == 'MacOS' %}
+{%-   set macos_group = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
+{%-   do template.update({'rootgroup': macos_group}) %}
+{%- endif %}

--- a/template/osfamilymap.yaml
+++ b/template/osfamilymap.yaml
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                                                             
+# -*- coding: utf-8 -*-
 # vim: ft=yaml
 #
 # Setup variables using grains['os_family'] based logic.
@@ -10,10 +10,6 @@
 # you will need to provide at least an empty dict in this file, e.g.
 # osfamilymap: {}
 ---
-{%- if grains.os == 'MacOS' %}
-{%-   set macos_rootgroup = salt['cmd.run']("stat -f '%Sg' /dev/console") %}
-{%- endif %}
-
 Debian:
   pkg:
     name: template-debian
@@ -48,5 +44,4 @@ Solaris: {}
 
 Windows: {}
 
-MacOS:
-  rootgroup: {{ macos_rootgroup | d('') }}
+MacOS: {}

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: template formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/centos6.sls
+++ b/test/salt/pillar/centos6.sls
@@ -12,9 +12,9 @@ template:
   # test the template formula itself. You should set these parameters to
   # examples that make sense in the contexto of the formula you're writing.
   pkg:
-    name: bash
+    name: cronie
   service:
-    name: systemd-udevd
+    name: crond
   config: /etc/template-formula.conf
 
   tofs:

--- a/test/salt/pillar/define_roles.sls
+++ b/test/salt/pillar/define_roles.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # libtofs.jinja must work with tofs.files_switch looked up list
 roles:
   - foo


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
template-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./test/integration/default/inspec.yml
  1:1       warning  missing document start "---"  (document-start)

./template/osfamilymap.yaml
  1:89      error    line too long (116 > 88 characters)  (line-length)
  1:24      error    trailing spaces  (trailing-spaces)
  13:2      error    syntax error: found character '%' that cannot start any token

pillar.example
  14:4      error    syntax error: found character '%' that cannot start any token
```

---

I've been testing out using `yamllint` on our formulas, centralising the changes using the `ssf-formula`.  I've added this to the `commitlint` stage, to make it an overall `lint` stage instead.  There have been very interesting results and I'm confident that this will be a very useful addition to our setup.

I've already tested this locally across a number of formulas and actually, this `template-formula` is the most complicated PR, in that it also required adding another suite to the testing.  The rest of the formulas are generally much simpler and I'll start pushing those soon, for consideration.

A change it will bring is having to move Jinja from our YAML files (since those are seen as syntax errors that can't be ignored) to the more appropriate locations.  Mainly `map.jinja` or even our `.sls` files (so far, I've found that the former is sufficient).  There are examples of this in the PR.