### PR TITLE
docs(reamde): special notes section

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -33,12 +33,19 @@ which contains the currently released version. This formula is versioned accordi
 
 See `Formula Versioning Section <https://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html#versioning>`_ for more details.
 
+If you need (non-default) configuration, please pay attention to the ``pillar.example`` file and/or `Special notes`_ section.
+
 Contributing to this repo
 -------------------------
 
 **Commit message formatting is significant!!**
 
 Please see :ref:`How to contribute <CONTRIBUTING>` for more details.
+
+Special notes
+-------------
+
+None
 
 Available states
 ----------------


### PR DESCRIPTION
Some formulas have unexpected defaults so README should flag this per "Special notes".

See https://github.com/saltstack-formulas/golang-formula/pull/26 for implementation example

This PR is independent of #21 though related.
