### PR TITLE
ci: use `dist: bionic` & apply `opensuse-leap-15` SCP error workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 ---
+dist: bionic
 stages:
   - test
   - lint
@@ -10,7 +11,6 @@ stages:
 sudo: required
 cache: bundler
 language: ruby
-dist: xenial
 
 services:
   - docker

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -200,6 +200,7 @@ These formulas are already compatible with semantic-release:
 * `ufw-formula <https://github.com/saltstack-formulas/ufw-formula>`_
 * `users-formula <https://github.com/saltstack-formulas/users-formula>`_
 * `vault-formula <https://github.com/saltstack-formulas/vault-formula>`_
+* `vim-formula <https://github.com/saltstack-formulas/vim-formula>`_
 * `vsftpd-formula <https://github.com/saltstack-formulas/vsftpd-formula>`_
 
 Documentation

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -43,6 +43,10 @@ platforms:
         - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
         - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
       run_command: /usr/lib/systemd/systemd
+    # Workaround to avoid intermittent failures on `opensuse-leap-15`:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
   - name: amazonlinux-2-develop-py2
     driver:
       image: netmanagers/salt-develop-py2:amazonlinux-2
@@ -67,6 +71,10 @@ platforms:
     driver:
       image: netmanagers/salt-2019.2-py3:opensuse-leap-15
       run_command: /usr/lib/systemd/systemd
+    # Workaround to avoid intermittent failures on `opensuse-leap-15`:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
   - name: amazonlinux-2-2019-2-py2
     driver:
       image: netmanagers/salt-2019.2-py2:amazonlinux-2
@@ -88,6 +96,10 @@ platforms:
     driver:
       image: netmanagers/salt-2018.3-py2:opensuse-leap-15
       run_command: /usr/lib/systemd/systemd
+    # Workaround to avoid intermittent failures on `opensuse-leap-15`:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
   - name: amazonlinux-2-2018-3-py2
     driver:
       image: netmanagers/salt-2018.3-py2:amazonlinux-2
@@ -110,6 +122,10 @@ platforms:
     driver:
       image: netmanagers/salt-2017.7-py2:opensuse-leap-15
       run_command: /usr/lib/systemd/systemd
+    # Workaround to avoid intermittent failures on `opensuse-leap-15`:
+    # => SCP did not finish successfully (255):  (Net::SCP::Error)
+    transport:
+      max_ssh_sessions: 1
   - name: amazonlinux-2-2017-7-py2
     driver:
       image: netmanagers/salt-2017.7-py2:amazonlinux-2


### PR DESCRIPTION
* Automated using https://github.com/myii/ssf-formula/pull/22
* Also:
  - https://github.com/myii/ssf-formula/pull/21

---

The [Ubuntu Bionic 18.04](https://docs.travis-ci.com/user/reference/bionic/) build environment is available for Travis CI.  Our current usage patterns are based on [Ubuntu Xenial 16.04](https://docs.travis-ci.com/user/reference/linux).  The plan here is to prefer the latest build environments available and spread this throughout our (`semantic-release`) formulas.

I've actually already run this across the formulas based on the link above.  This has thrown up an ongoing problem that would be really good to solve at the same time: `opensuse-leap-15` regularly fails in almost half of the formulas and always with the same error:

* `SCP did not finish successfully (): (Net::SCP::Error)`

Usually, a single restart gets around this.  Sometimes, even multiple restarts aren't enough.  We really need to solve this or consider dropping back to `opensuse-leap-42` in the meantime.