### PR TITLE
docs(bug_report): add section requesting commit hash / release tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -62,7 +62,7 @@ Notes:
 
 ---
 
-### Optional: How can this template be improved?
+### Meta: How can this template be improved?
 <!-- Feel free to suggest how this template can be improved. -->
 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,6 +36,11 @@ Notes:
 
 
 
+#### Formula commit hash / release tag
+<!-- Please specify the formula's commit hash and/or release tag that you are using. -->
+
+
+
 #### Versions report
 <!-- Provided by running `salt --versions-report`. Please also mention any differences in master/minion versions. -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,46 +14,46 @@ Notes:
 3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
 -->
 
-#### Describe the bug
+### Describe the bug
 <!-- A clear and concise description of what the bug is. -->
 
 
 
-#### Setup
+### Setup
 <!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->
 
 
 
-#### Steps to reproduce the bug
+### Steps to reproduce the bug
 <!-- Include debug logs if possible and relevant, e.g. using `salt-minion -l debug`. -->
 <!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
 <!-- Most useful is providing a failing InSpec test, which can be used to verify any proposed fix. -->
 
 
 
-#### Expected behaviour
+### Expected behaviour
 <!-- A clear and concise description of what you expected to happen. -->
 
 
 
-#### Formula commit hash / release tag
+### Formula commit hash / release tag
 <!-- Please specify the formula's commit hash and/or release tag that you are using. -->
 
 
 
-#### Versions report
+### Versions report
 <!-- Provided by running `salt --versions-report`. Please also mention any differences in master/minion versions. -->
 
 
 
-#### Additional context
+### Additional context
 <!-- Add any other context about the problem here. -->
 
 
 
 ---
 
-#### Optional: How can this template be improved?
+### Optional: How can this template be improved?
 <!-- Feel free to suggest how this template can be improved. -->
 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,13 +14,27 @@ Notes:
 3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
 -->
 
+## Your setup
+### Formula commit hash / release tag
+<!-- Please specify the formula's commit hash and/or release tag that you are using. -->
+
+
+
+### Versions reports (master & minion)
+<!-- Provided by running `salt --versions-report`. Please also mention any differences in master/minion versions. -->
+
+
+
+### Pillar / config used
+<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->
+
+
+
+---
+
+## Bug details
 ### Describe the bug
 <!-- A clear and concise description of what the bug is. -->
-
-
-
-### Setup
-<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->
 
 
 
@@ -36,13 +50,8 @@ Notes:
 
 
 
-### Formula commit hash / release tag
-<!-- Please specify the formula's commit hash and/or release tag that you are using. -->
-
-
-
-### Versions report
-<!-- Provided by running `salt --versions-report`. Please also mention any differences in master/minion versions. -->
+### Attempts to fix the bug
+<!-- Please mention any attempts you have made to fix the bug and what the results were. -->
 
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -36,7 +36,7 @@ Notes:
 
 ---
 
-### Optional: How can this template be improved?
+### Meta: How can this template be improved?
 <!-- Feel free to suggest how this template can be improved. -->
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,29 +14,29 @@ Notes:
 3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
 -->
 
-#### Is your feature request related to a problem?
+### Is your feature request related to a problem?
 <!-- A clear and concise description of what the problem is. -->
 
 
 
-#### Describe the solution you'd like
+### Describe the solution you'd like
 <!-- A clear and concise description of what you want to happen. -->
 
 
 
-#### Describe alternatives you've considered
+### Describe alternatives you've considered
 <!-- Describe any alternative solutions or features you've considered. -->
 
 
 
-#### Additional context
+### Additional context
 <!-- Add any other context about the feature request here. -->
 
 
 
 ---
 
-#### Optional: How can this template be improved?
+### Optional: How can this template be improved?
 <!-- Feel free to suggest how this template can be improved. -->
 
 


### PR DESCRIPTION
* Useful to have this provided in a bug report, e.g.
  - https://github.com/saltstack-formulas/postfix-formula/issues/100

---

The linked example is one of the first bug reports using the new template.  The template is using level 4 headings at the current time.  Should these all be increased to level 3?  If so, I can attach that to this PR, along with the same change to the feature request template.