### PR TITLE
[ssf] ci(travis): opt-in to `dpl v2` to complete build config validation [skip ci]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,8 +115,9 @@ jobs:
                    @semantic-release/git@7
       deploy:
         provider: 'script'
-        # Using deprecated `skip_cleanup` until `cleanup: false` works reliably
-        # cleanup: false
-        skip_cleanup: true
+        # Opt-in to `dpl v2` to complete the Travis build config validation (beta)
+        # * https://docs.travis-ci.com/user/build-config-validation
+        # Deprecated `skip_cleanup` can now be avoided, `cleanup: false` is by default
+        edge: true
         # Run `semantic-release`
         script: 'npx semantic-release@15'


### PR DESCRIPTION
* Automated using https://github.com/myii/ssf-formula/pull/100

---

As discussed, setting up a PR here before propagating to all of the `semantic-release` formulas.  This one is to finalise using the new Travis beta feature (build config validation) after being informed about the final part of the jigsaw here:

* https://github.com/travis-ci/dpl/issues/1138#issuecomment-554988130

I've already confirmed this is working by pushing this to the `apache-formula`:

* https://travis-ci.com/saltstack-formulas/apache-formula/builds/137005150

Notice that `View config` no longer shows any errors or warnings:

* https://travis-ci.com/saltstack-formulas/apache-formula/builds/137005150/config