### PR TITLE
[ssf] ci(travis): run `shellcheck` during lint job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,13 @@ jobs:
     - language: 'node_js'
       node_js: 'lts/*'
       env: 'Lint'
-      name: 'Lint: salt-lint, yamllint, rubocop & commitlint'
+      name: 'Lint: salt-lint, yamllint, rubocop, shellcheck & commitlint'
       before_install: 'skip'
       script:
         # Install and run `salt-lint`
         - pip install --user salt-lint
-        - git ls-files | grep '\.sls$\|\.jinja$\|\.j2$\|\.tmpl$\|\.tst$'
-                       | xargs salt-lint
+        - git ls-files -- *.sls *.jinja *.j2 *.tmpl *.tst
+                        | xargs salt-lint
         # Install and run `yamllint`
         # Need at least `v1.17.0` for the `yaml-files` setting
         - pip install --user yamllint>=1.17.0
@@ -46,6 +46,10 @@ jobs:
         # Install and run `rubocop`
         - gem install rubocop
         - rubocop -d
+        # Run `shellcheck` (already pre-installed in Travis)
+        - shellcheck --version
+        - git ls-files -- *.sh *.bash *.ksh
+                        | xargs shellcheck
         # Install and run `commitlint`
         - npm i -D @commitlint/config-conventional
                    @commitlint/travis-cli

--- a/pre-commit_semantic-release.sh
+++ b/pre-commit_semantic-release.sh
@@ -14,9 +14,9 @@ sed -i -e "s_^\(version:\).*_\1 ${1}_" FORMULA
 sudo -H pip install m2r
 
 # Copy and then convert the `.md` docs
-cp *.md docs/
-cd docs/
-m2r --overwrite *.md
+cp ./*.md docs/
+cd docs/ || exit
+m2r --overwrite ./*.md
 
 # Change excess `H1` headings to `H2` in converted `CHANGELOG.rst`
 sed -i -e '/^=.*$/s/=/-/g' CHANGELOG.rst


### PR DESCRIPTION
* Automated using https://github.com/myii/ssf-formula/pull/106

---

To be propagated across all formulas using the `ssf-formula`.  According to our discussions, this only requires _one approval_, since it's only CI-based changes.

Idea started from here:

* https://github.com/saltstack-formulas/template-formula/pull/180#issuecomment-558612422

As `shellcheck` is already integrated into Travis, this is easy to run and asides from here, already tested elsewhere:

* https://travis-ci.com/saltstack-formulas/fail2ban-formula/jobs/260717687#L215-L216
* https://travis-ci.org/myii/ssf-formula/builds/617730995#L206-L207

An example of failures (`shellcheck` has excellent error descriptions):

* https://travis-ci.org/myii/ssf-formula/builds/617359726#L206-L367