### PR TITLE
style(inspec): match current practices for file and control names

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@
 /*/_mapdata/                                @saltstack-formulas/ssf
 /*/libsaltcli.jinja                         @saltstack-formulas/ssf
 /*/libtofs.jinja                            @saltstack-formulas/ssf
-/test/integration/**/_mapdata_spec.rb       @saltstack-formulas/ssf
+/test/integration/**/_mapdata.rb            @saltstack-formulas/ssf
 /test/integration/**/libraries/system.rb    @saltstack-formulas/ssf
 /test/integration/**/inspec.yml             @saltstack-formulas/ssf
 /test/integration/**/README.md              @saltstack-formulas/ssf

--- a/test/integration/default/controls/_mapdata.rb
+++ b/test/integration/default/controls/_mapdata.rb
@@ -2,8 +2,8 @@
 
 require 'yaml'
 
-control '`map.jinja` YAML dump' do
-  title 'should match the comparison file'
+control 'TEMPLATE._mapdata' do
+  title '`map.jinja` should match the reference file'
 
   ### Method
   # The steps below for each file appear convoluted but they are both required

--- a/test/integration/default/controls/config.rb
+++ b/test/integration/default/controls/config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-control 'TEMPLATE configuration' do
-  title 'should match desired lines'
+control 'TEMPLATE.config.file' do
+  title 'Verify the configuration file'
 
   describe file('/etc/template-formula.conf') do
     it { should be_file }

--- a/test/integration/default/controls/packages.rb
+++ b/test/integration/default/controls/packages.rb
@@ -3,22 +3,19 @@
 # Prepare platform "finger"
 platform_finger = system.platform[:finger].split('.').first.to_s
 
-control 'TEMPLATE service' do
-  impact 0.5
-  title 'should be running and enabled'
+control 'TEMPLATE.package.install' do
+  title 'The required package should be installed'
 
   # Overide by `platform_finger`
-  service_name =
+  package_name =
     case platform_finger
     when 'centos-6', 'amazonlinux-1'
-      'crond'
+      'cronie'
     else
-      'systemd-journald'
+      'bash'
     end
 
-  describe service(service_name) do
+  describe package(package_name) do
     it { should be_installed }
-    it { should be_enabled }
-    it { should be_running }
   end
 end

--- a/test/integration/default/controls/services.rb
+++ b/test/integration/default/controls/services.rb
@@ -3,19 +3,21 @@
 # Prepare platform "finger"
 platform_finger = system.platform[:finger].split('.').first.to_s
 
-control 'TEMPLATE package' do
-  title 'should be installed'
+control 'TEMPLATE.service.running' do
+  title 'The service should be installed, enabled and running'
 
   # Overide by `platform_finger`
-  package_name =
+  service_name =
     case platform_finger
     when 'centos-6', 'amazonlinux-1'
-      'cronie'
+      'crond'
     else
-      'bash'
+      'systemd-journald'
     end
 
-  describe package(package_name) do
+  describe service(service_name) do
     it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
   end
 end

--- a/test/integration/default/controls/subcomponent_config.rb
+++ b/test/integration/default/controls/subcomponent_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-control 'TEMPLATE subcomponent configuration' do
-  title 'should match desired lines'
+control 'TEMPLATE.subcomponent.config.file' do
+  title 'Verify the subcomponent configuration file'
 
   describe file('/etc/TEMPLATE-subcomponent-formula.conf') do
     it { should be_file }


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [x] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [x] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

I don't find a reference best practices in the documentation but:

- the `_spec` in the control file name is inherited from RSpec and few examples use it

- the `control` name should be an identifier, I matched the `tpldot` name

- the `title` is a human readable description of the `control`


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

Now the output looks like this:

```
  ✔  TEMPLATE.config.file: verify the template-formula.conf lines
     ✔  File /etc/template-formula.conf is expected to be file
     ✔  File /etc/template-formula.conf is expected to be owned by "root"
     […]	 	 
  ✔  TEMPLATE.subcomponent.config.file: verify the subcomponent configuration file
     ✔  File /etc/TEMPLATE-subcomponent-formula.conf is expected to be file
     ✔  File /etc/TEMPLATE-subcomponent-formula.conf is expected to be owned by "root"
     […]

  ✔  TEMPLATE._mapdata: `map.jinja` should match the reference file
     ✔  File /tmp/salt_mapdata_dump.yaml is expected to exist
     ✔  File /tmp/salt_mapdata_dump.yaml content is expected to eq "# yamllint disable rule:indentation rule:line-length\n# CentOS Linux-8\n---\nadded_in_defaults: defa...ATE-subcomponent-config-file-file-managed:\n    - subcomponent-example.tmpl.jinja\nwinner: pillar\n"
  ✔  TEMPLATE.package.install: required package should be installed
     ✔  System Package bash is expected to be installed
  ✔  TEMPLATE.service.running: the service should be running and enabled
     ✔  Service systemd-journald is expected to be installed
     ✔  Service systemd-journald is expected to be enabled
     ✔  Service systemd-journald is expected to be running
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

We spoke abouth this in [Salt Formula Working Group 2020-09-08](https://youtu.be/MJRH01TbOQU?t=1975)
