### PR TITLE
fix(map): workaround salt bug with Jinja2 3.0

### DIFF
--- a/TEMPLATE/libmapstack.jinja
+++ b/TEMPLATE/libmapstack.jinja
@@ -3,7 +3,7 @@
 
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split("/")[0] %}
-{%- from tplroot ~ "/libmatchers.jinja" import parse_matchers, query_map %}
+{%- from tplroot ~ "/libmatchers.jinja" import parse_matchers, query_map with context %}
 
 {%- set _default_config_dirs = [
       "parameters/",
@@ -231,7 +231,7 @@
                 ~ yaml_filename
               ) %}
 {%-           load_yaml as yaml_values %}
-{%-             include yaml_filename ignore missing %}
+{%-             include yaml_filename ignore missing with context %}
 {%-           endload %}
 
 {%-           if yaml_values %}

--- a/TEMPLATE/libmatchers.jinja
+++ b/TEMPLATE/libmatchers.jinja
@@ -3,7 +3,7 @@
 
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split("/")[0] %}
-{%- from tplroot ~ "/libsaltcli.jinja" import cli %}
+{%- from tplroot ~ "/libsaltcli.jinja" import cli with context %}
 
 {%- set query_map = {
       "C": "config.get",

--- a/TEMPLATE/map.jinja
+++ b/TEMPLATE/map.jinja
@@ -3,7 +3,7 @@
 
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split("/")[0] %}
-{%- from tplroot ~ "/libmapstack.jinja" import mapstack %}
+{%- from tplroot ~ "/libmapstack.jinja" import mapstack with context %}
 
 {#- Where to lookup parameters source files #}
 {%- set formula_param_dir = tplroot ~ "/parameters" %}
@@ -63,4 +63,4 @@
 
 {#- Per formula post-processing of `mapdata` if it exists #}
 {%- do salt["log.debug"]("map.jinja: post-processing of 'mapdata'") %}
-{%- include tplroot ~ "/post-map.jinja" ignore missing %}
+{%- include tplroot ~ "/post-map.jinja" ignore missing with context %}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

https://github.com/saltstack/salt/issues/60188

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

A change in Jinja2 3.0 cause troubles in rendering templates where salt special variables are available only on first import but not subsequent ones (see https://github.com/saltstack/salt/issues/60188)

We could workaround that bug by explicitly import jinja libraries and load YAML files `with context`.

* TEMPLATE/map.jinja: import `libmapstack.jinja` and `post-map.jinja` with context.

* TEMPLATE/libmapstack.jinja: import `libmatchers.jinja` with context.
  Load YAML files with context.

* TEMPLATE/libmatchers.jinja: import `libsaltcli.jinja` with context.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

I tested by running the following commands:

1. create the openSUSE Tumbleweed container:
   <details><summary>./bin/kitchen create default-opensuse-tmbl-latest-master-py3</summary>

   ```
   -----> Starting Test Kitchen (v3.0.0)
   -----> Creating <default-opensuse-tmbl-latest-master-py3>...
          Sending build context to Docker daemon   1.69MB
          Step 1/14 : FROM saltimages/salt-master-py3:opensuse-tumbleweed-latest
          opensuse-tumbleweed-latest: Pulling from saltimages/salt-master-py3
          4484fbece60c: Pulling fs layer
          01b020139116: Pulling fs layer
          4484fbece60c: Verifying Checksum
          4484fbece60c: Download complete
          4484fbece60c: Pull complete
          01b020139116: Download complete
          01b020139116: Pull complete
          Digest: sha256:970d60ed266acef9e750a521ff98e38d689bb4e48a2192d7be120d7c7396484e
          Status: Downloaded newer image for saltimages/salt-master-py3:opensuse-tumbleweed-latest
           ---> 1619865dc023
          Step 2/14 : ENV container docker
           ---> Running in a5e32055da88
          Removing intermediate container a5e32055da88
           ---> a6845cebed90
          Step 3/14 : RUN /usr/sbin/sshd-gen-keys-start
           ---> Running in 8849e1a9f96f
          + /usr/sbin/sshd-gen-keys-start
          Checking for missing server keys in /etc/ssh
          ssh-keygen: generating new host keys: RSA DSA ECDSA ED25519 
          Removing intermediate container 8849e1a9f96f
           ---> ccf529bfa280
          Step 4/14 : RUN if ! getent passwd kitchen; then                   useradd -d /home/kitchen -m -s /bin/bash -p '*' kitchen;                 fi
           ---> Running in f020684a1c1b
          + getent passwd kitchen
          + useradd -d /home/kitchen -m -s /bin/bash -p '*' kitchen
          Group 'mail' not found. Creating the user mailbox file with 0600 mode.
          Removing intermediate container f020684a1c1b
           ---> 0e602b6cff92
          Step 5/14 : RUN echo "kitchen ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/kitchen
           ---> Running in 906fc9eed506
          + echo 'kitchen ALL=(ALL) NOPASSWD: ALL'
          Removing intermediate container 906fc9eed506
           ---> b417228c3a22
          Step 6/14 : RUN echo "Defaults !requiretty" >> /etc/sudoers.d/kitchen
           ---> Running in cf98427711a6
          + echo 'Defaults !requiretty'
          Removing intermediate container cf98427711a6
           ---> fc93c7e7d3f8
          Step 7/14 : RUN mkdir -p /home/kitchen/.ssh
           ---> Running in 1d3c5ef2ef74
          + mkdir -p /home/kitchen/.ssh
          Removing intermediate container 1d3c5ef2ef74
           ---> e210b5cc4d12
          Step 8/14 : RUN chown -R kitchen /home/kitchen/.ssh
           ---> Running in c9a8af98f017
          + chown -R kitchen /home/kitchen/.ssh
          Removing intermediate container c9a8af98f017
           ---> 03d86d583d21
          Step 9/14 : RUN chmod 0700 /home/kitchen/.ssh
           ---> Running in 6689a8ce1eb8
          + chmod 0700 /home/kitchen/.ssh
          Removing intermediate container 6689a8ce1eb8
           ---> b85a8cfe6fde
          Step 10/14 : RUN touch /home/kitchen/.ssh/authorized_keys
           ---> Running in 1d5699e7967f
          + touch /home/kitchen/.ssh/authorized_keys
          Removing intermediate container 1d5699e7967f
           ---> 3debc288fd00
          Step 11/14 : RUN chown kitchen /home/kitchen/.ssh/authorized_keys
           ---> Running in 53208375328e
          + chown kitchen /home/kitchen/.ssh/authorized_keys
          Removing intermediate container 53208375328e
           ---> 79cc978e41c5
          Step 12/14 : RUN chmod 0600 /home/kitchen/.ssh/authorized_keys
           ---> Running in 2d14239749fd
          + chmod 0600 /home/kitchen/.ssh/authorized_keys
          Removing intermediate container 2d14239749fd
           ---> 102765cb1dd4
          Step 13/14 : RUN mkdir -p /run/sshd
           ---> Running in a5bc485124b7
          + mkdir -p /run/sshd
          Removing intermediate container a5bc485124b7
           ---> ea1f0121ce22
          Step 14/14 : RUN echo ssh-rsa\ AAAAB3NzaC1yc2EAAAADAQABAAABAQC0qGWjzwmaB0gvhDTvqJQnZjMhCJKjyRbu7jF9I/2mygJI+C5pMOULZ44su4f0TuVa9MBm3Zx7ro0c2bsXm/ql9UkCIJ8oRsH/yKwyzMMGWzLeDaAtV56+txCeCXpl7AY4T3gHLY+okuqEAOYHq1gdGIvJqVqLAfl9WEmhlsXF4taL1bYhu4GcztHcAOHXvgIxHTdzeIJ19GPA0xM2S6LifxoUMzS6ihOs4j869m4IlOO4Pg9j3GKGsvp9QArT6m0XD8FXna1r+qRbI+JGR7aEdYXC+PmkTFDmFWKAUEN0R+0kgzJt4xgLK52LHwG0zJypCOXfGnWUjNX8eao/hqsl\ kitchen_docker_key >> /home/kitchen/.ssh/authorized_keys
           ---> Running in 8369bfa907c2
          + echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0qGWjzwmaB0gvhDTvqJQnZjMhCJKjyRbu7jF9I/2mygJI+C5pMOULZ44su4f0TuVa9MBm3Zx7ro0c2bsXm/ql9UkCIJ8oRsH/yKwyzMMGWzLeDaAtV56+txCeCXpl7AY4T3gHLY+okuqEAOYHq1gdGIvJqVqLAfl9WEmhlsXF4taL1bYhu4GcztHcAOHXvgIxHTdzeIJ19GPA0xM2S6LifxoUMzS6ihOs4j869m4IlOO4Pg9j3GKGsvp9QArT6m0XD8FXna1r+qRbI+JGR7aEdYXC+PmkTFDmFWKAUEN0R+0kgzJt4xgLK52LHwG0zJypCOXfGnWUjNX8eao/hqsl kitchen_docker_key'
          Removing intermediate container 8369bfa907c2
           ---> 82f3417e0d1f
          Successfully built 82f3417e0d1f
          74230d4c8bf47ef526afa920dcd84b0f2153e12cef1ffbe8ab7be0bb993f81cb
          0.0.0.0:49263
          Waiting for SSH service on localhost:49263, retrying in 3 seconds
          [SSH] Established
          Finished creating <default-opensuse-tmbl-latest-master-py3> (1m17.81s).
   -----> Test Kitchen is finished. (1m18.65s)
   ```
   </details>
2. install the 3.x Jinja2 library
   <details><summary>./bin/kitchen exec -c 'sudo zypper install --no-confirm python3-jinja2' default-opensuse-tmbl-latest-master-py3</summary>

   ```
   -----> Execute command on default-opensuse-tmbl-latest-master-py3.
   Retrieving repository 'openSUSE-Tumbleweed-Non-Oss' metadata .............[done]
   Building repository 'openSUSE-Tumbleweed-Non-Oss' cache ..................[done]
   Retrieving repository 'openSUSE-Tumbleweed-Oss' metadata .................[done]
   Building repository 'openSUSE-Tumbleweed-Oss' cache ......................[done]
   Retrieving repository 'Salt configuration management for openSUSE (openSUS[done]
   Building repository 'Salt configuration management for openSUSE (openSUSE_[done]
          Loading repository data...
          Reading installed packages...
          'python38-jinja2' not found in package names. Trying capabilities.
          Resolving package dependencies...
          
          The following 5 NEW packages are going to be installed:
            python38-Babel python38-Jinja2 python38-MarkupSafe python38-pytz timezone
          
          5 new packages to install.
          Overall download size: 6,6 MiB. Already cached: 0 B. After the operation,
          additional 30,0 MiB will be used.
   Continue? [y/n/v/...? shows all options] (y): y
          Retrieving package python38-MarkupSafe-2.0.1-1.1.x86_64
                                              (1/5),  31,3 KiB ( 66,8 KiB unpacked)
   Retrieving: python38-MarkupSafe-2.0.1-1.1.x86_64.rpm .....................[done]
          Retrieving package timezone-2021a-2.1.x86_64
                                              (2/5), 442,4 KiB (  1,3 MiB unpacked)
   Retrieving: timezone-2021a-2.1.x86_64.rpm ................................[done]
          Retrieving package python38-pytz-2021.1-5.1.noarch
                                              (3/5),  59,7 KiB (239,5 KiB unpacked)
   Retrieving: python38-pytz-2021.1-5.1.noarch.rpm ..........................[done]
          Retrieving package python38-Babel-2.9.1-1.2.noarch
                                              (4/5),   5,8 MiB ( 27,1 MiB unpacked)
   Retrieving: python38-Babel-2.9.1-1.2.noarch.rpm ..........................[done]
          Retrieving package python38-Jinja2-3.0.1-1.1.x86_64
                                              (5/5), 286,9 KiB (  1,3 MiB unpacked)
   Retrieving: python38-Jinja2-3.0.1-1.1.x86_64.rpm .........................[done]
          
   Checking for file conflicts: .............................................[done]
   (1/5) Installing: python38-MarkupSafe-2.0.1-1.1.x86_64 ...................[done]
   (2/5) Installing: timezone-2021a-2.1.x86_64 ..............................[done]
   (3/5) Installing: python38-pytz-2021.1-5.1.noarch ........................[done]
   (4/5) Installing: python38-Babel-2.9.1-1.2.noarch ........................[done]
   (5/5) Installing: python38-Jinja2-3.0.1-1.1.x86_64 .......................[done]
   ```
   </details>
3. test the formula
   <details><summary>./bin/kitchen verify default-opensuse-tmbl-latest-master-py3</summary>
   
   ```
   -----> Starting Test Kitchen (v3.0.0)
   -----> Converging <default-opensuse-tmbl-latest-master-py3>...
          Preparing files for transfer
          Preparing salt-minion
          Preparing pillars into /srv/pillar
          Preparing formula: TEMPLATE from /root/template-formula
          Preparing state_top
          Preparing scripts into /etc/salt/scripts
          You asked for latest and you have 3004+0na.38906ff installed, sweet!
          Transferring files to <default-opensuse-tmbl-latest-master-py3>
          Install External Dependencies
          Content of /tmp/kitchen//srv/salt :
          total 4
          drwxr-xr-x 3 kitchen users  80 août  31 09:53 .
          drwxr-xr-x 4 kitchen users  80 août  31 09:53 ..
          drwxr-xr-x 9 kitchen users 320 août  31 09:53 TEMPLATE
          -rw-r--r-- 1 kitchen users  52 août  31 09:53 top.sls
          [DEBUG   ] Reading configuration from /tmp/kitchen/etc/salt/minion
          [DEBUG   ] Guessing ID. The id can be explicitly set in /etc/salt/minion
          [DEBUG   ] Found minion id from generate_minion_id(): 74230d4c8bf4
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Override  __grains__: <module 'salt.loaded.int.log_handlers.sentry_mod' from '/usr/lib/python3.8/site-packages/salt/log/handlers/sentry_mod.py'>
          [DEBUG   ] Configuration file path: /tmp/kitchen/etc/salt/minion
          [WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
          [DEBUG   ] Grains refresh requested. Refreshing grains.
          [DEBUG   ] Reading configuration from /tmp/kitchen/etc/salt/minion
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Override  __utils__: <module 'salt.loaded.int.grains.zfs' from '/usr/lib/python3.8/site-packages/salt/grains/zfs.py'>
          [DEBUG   ] Elapsed time getting FQDNs: 0.02135443687438965 seconds
          [DEBUG   ] The `lspci` binary is not available on the system. GPU grains will not be available.
          [DEBUG   ] LazyLoaded zfs.is_supported
          [DEBUG   ] Determining pillar cache
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded jinja.render
          [DEBUG   ] LazyLoaded yaml.render
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] compile template: /tmp/kitchen/srv/pillar/top.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/srv/pillar', '/tmp/kitchen/srv/spm/pillar']
          [DEBUG   ] Using pkg_resources to load entry points
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/srv/pillar/top.sls' using 'jinja' renderer: 0.009171009063720703
          [DEBUG   ] Rendered data from file: /tmp/kitchen/srv/pillar/top.sls:
          ---
          base:
            "*":
            - TEMPLATE
            - define_roles
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('base', OrderedDict([('*', ['TEMPLATE', 'define_roles'])]))])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/srv/pillar/top.sls' using 'yaml' renderer: 0.0005297660827636719
          [DEBUG   ] LazyLoaded confirm_top.confirm_top
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded compound_match.match
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] compound_match: 74230d4c8bf4 ? *
          [DEBUG   ] LazyLoaded glob_match.match
          [DEBUG   ] compound_match 74230d4c8bf4 ? "*" => "True"
          [DEBUG   ] compile template: /tmp/kitchen/srv/pillar/TEMPLATE.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/srv/pillar', '/tmp/kitchen/srv/spm/pillar']
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/srv/pillar/TEMPLATE.sls' using 'jinja' renderer: 0.0013492107391357422
          [DEBUG   ] Rendered data from file: /tmp/kitchen/srv/pillar/TEMPLATE.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=yaml
          ---
          TEMPLATE:
            lookup:
              master: template-master
              # Just for testing purposes
              winner: lookup
              added_in_lookup: lookup_value
          
            # Using bash package and udev service as an example. This allows us to
            # test the template formula itself. You should set these parameters to
            # examples that make sense in the contexto of the formula you're writing.
            pkg:
              name: bash
            service:
              name: systemd-journald
            config: /etc/template-formula.conf
          
            tofs:
              # The files_switch key serves as a selector for alternative
              # directories under the formula files directory. See TOFS pattern
              # doc for more info.
              # Note: Any value not evaluated by `config.get` will be used literally.
              # This can be used to set custom paths, as many levels deep as required.
              files_switch:
                - any/path/can/be/used/here
                - id
                - roles
                - osfinger
                - os
                - os_family
              # All aspects of path/file resolution are customisable using the options below.
              # This is unnecessary in most cases; there are sensible defaults.
              # Default path: salt://< path_prefix >/< dirs.files >/< dirs.default >
              #         I.e.: salt://TEMPLATE/files/default
              # path_prefix: template_alt
              # dirs:
              #   files: files_alt
              #   default: default_alt
              # The entries under `source_files` are prepended to the default source files
              # given for the state
              # source_files:
              #   TEMPLATE-config-file-file-managed:
              #     - 'example_alt.tmpl'
              #     - 'example_alt.tmpl.jinja'
          
              # For testing purposes
              source_files:
                TEMPLATE-config-file-file-managed:
           - 'example.tmpl.jinja'
                TEMPLATE-subcomponent-config-file-file-managed:
           - 'subcomponent-example.tmpl.jinja'
          
            # Just for testing purposes
            winner: pillar
            added_in_pillar: pillar_value
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('TEMPLATE', OrderedDict([('lookup', OrderedDict([('master', 'template-master'), ('winner', 'lookup'), ('added_in_lookup', 'lookup_value')])), ('pkg', OrderedDict([('name', 'bash')])), ('service', OrderedDict([('name', 'systemd-journald')])), ('config', '/etc/template-formula.conf'), ('tofs', OrderedDict([('files_switch', ['any/path/can/be/used/here', 'id', 'roles', 'osfinger', 'os', 'os_family']), ('source_files', OrderedDict([('TEMPLATE-config-file-file-managed', ['example.tmpl.jinja']), ('TEMPLATE-subcomponent-config-file-file-managed', ['subcomponent-example.tmpl.jinja'])]))])), ('winner', 'pillar'), ('added_in_pillar', 'pillar_value')]))])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/srv/pillar/TEMPLATE.sls' using 'yaml' renderer: 0.0009336471557617188
          [DEBUG   ] compile template: /tmp/kitchen/srv/pillar/define_roles.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/srv/pillar', '/tmp/kitchen/srv/spm/pillar']
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/srv/pillar/define_roles.sls' using 'jinja' renderer: 0.0008034706115722656
          [DEBUG   ] Rendered data from file: /tmp/kitchen/srv/pillar/define_roles.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=yaml
          ---
          # libtofs.jinja must work with tofs.files_switch looked up list
          roles:
            - foo
            - bar
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('roles', ['foo', 'bar'])])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/srv/pillar/define_roles.sls' using 'yaml' renderer: 0.0003197193145751953
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded jinja.render
          [DEBUG   ] LazyLoaded yaml.render
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded state.highstate
          [DEBUG   ] LazyLoaded direct_call.execute
          [DEBUG   ] Override  __grains__: <module 'salt.loaded.int.module.grains' from '/usr/lib/python3.8/site-packages/salt/modules/grains.py'>
          [DEBUG   ] LazyLoaded grains.get
          [DEBUG   ] LazyLoaded saltutil.is_running
          [DEBUG   ] LazyLoaded config.get
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [DEBUG   ] Updating roots fileserver cache
          [DEBUG   ] Gathering pillar data for state run
          [DEBUG   ] Finished gathering pillar data for state run
          [INFO    ] Loading fresh modules for state activity
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded jinja.render
          [DEBUG   ] LazyLoaded yaml.render
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] In saltenv 'base', looking at rel_path 'top.sls' to resolve 'salt://top.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/top.sls' to resolve 'salt://top.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://top.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'top.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/top.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/top.sls' using 'jinja' renderer: 0.024801254272460938
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/top.sls:
          ---
          base:
            "*":
            - TEMPLATE._mapdata
            - TEMPLATE
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('base', OrderedDict([('*', ['TEMPLATE._mapdata', 'TEMPLATE'])]))])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/top.sls' using 'yaml' renderer: 0.0007207393646240234
          [DEBUG   ] LazyLoaded confirm_top.confirm_top
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded compound_match.match
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] compound_match: 74230d4c8bf4 ? *
          [DEBUG   ] LazyLoaded glob_match.match
          [DEBUG   ] compound_match 74230d4c8bf4 ? "*" => "True"
          [DEBUG   ] LazyLoaded saltutil.sync_all
          [DEBUG   ] Syncing all
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/clouds'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing clouds for environment 'base'
          [INFO    ] Loading cache from salt://_clouds, for base
          [INFO    ] Caching directory '_clouds/' for environment 'base'
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_clouds'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/beacons'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing beacons for environment 'base'
          [INFO    ] Loading cache from salt://_beacons, for base
          [INFO    ] Caching directory '_beacons/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_beacons'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/modules'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing modules for environment 'base'
          [INFO    ] Loading cache from salt://_modules, for base
          [INFO    ] Caching directory '_modules/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_modules'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/states'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing states for environment 'base'
          [INFO    ] Loading cache from salt://_states, for base
          [INFO    ] Caching directory '_states/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_states'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/sdb'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing sdb for environment 'base'
          [INFO    ] Loading cache from salt://_sdb, for base
          [INFO    ] Caching directory '_sdb/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_sdb'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/grains'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing grains for environment 'base'
          [INFO    ] Loading cache from salt://_grains, for base
          [INFO    ] Caching directory '_grains/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_grains'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/renderers'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing renderers for environment 'base'
          [INFO    ] Loading cache from salt://_renderers, for base
          [INFO    ] Caching directory '_renderers/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_renderers'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/returners'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing returners for environment 'base'
          [INFO    ] Loading cache from salt://_returners, for base
          [INFO    ] Caching directory '_returners/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_returners'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/output'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing output for environment 'base'
          [INFO    ] Loading cache from salt://_output, for base
          [INFO    ] Caching directory '_output/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_output'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/utils'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing utils for environment 'base'
          [INFO    ] Loading cache from salt://_utils, for base
          [INFO    ] Caching directory '_utils/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_utils'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/log_handlers'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing log_handlers for environment 'base'
          [INFO    ] Loading cache from salt://_log_handlers, for base
          [INFO    ] Caching directory '_log_handlers/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_log_handlers'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/executors'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing executors for environment 'base'
          [INFO    ] Loading cache from salt://_executors, for base
          [INFO    ] Caching directory '_executors/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_executors'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/proxy'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing proxy for environment 'base'
          [INFO    ] Loading cache from salt://_proxy, for base
          [INFO    ] Caching directory '_proxy/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_proxy'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/engines'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing engines for environment 'base'
          [INFO    ] Loading cache from salt://_engines, for base
          [INFO    ] Caching directory '_engines/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_engines'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/thorium'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing thorium for environment 'base'
          [INFO    ] Loading cache from salt://_thorium, for base
          [INFO    ] Caching directory '_thorium/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_thorium'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/serializers'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing serializers for environment 'base'
          [INFO    ] Loading cache from salt://_serializers, for base
          [INFO    ] Caching directory '_serializers/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_serializers'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/matchers'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing matchers for environment 'base'
          [INFO    ] Loading cache from salt://_matchers, for base
          [INFO    ] Caching directory '_matchers/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_matchers'
          [INFO    ] Creating module dir '/tmp/kitchen/var/cache/salt/minion/extmods/pillar'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [INFO    ] Syncing pillar for environment 'base'
          [INFO    ] Loading cache from salt://_pillar, for base
          [INFO    ] Caching directory '_pillar/' for environment 'base'
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Local cache dir: '/tmp/kitchen/var/cache/salt/minion/files/base/_pillar'
          [DEBUG   ] Refreshing modules...
          [INFO    ] Loading fresh modules for state activity
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded jinja.render
          [DEBUG   ] LazyLoaded yaml.render
          [DEBUG   ] Returning file list from cache: age=0 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Could not find file 'salt://TEMPLATE/_mapdata.sls' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/_mapdata/init.sls' to resolve 'salt://TEMPLATE/_mapdata/init.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/_mapdata/init.sls' to resolve 'salt://TEMPLATE/_mapdata/init.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/_mapdata/init.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/_mapdata/init.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/_mapdata/init.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] LazyLoaded log.debug
          [DEBUG   ] [libsaltcli] the salt command type has been identified to be: local
          [DEBUG   ] LazyLoaded config.get
          [DEBUG   ] map.jinja configuration: process matcher: 'map_jinja.yaml'
          [DEBUG   ] map.jinja configuration: use built-in defaults for matcher:
              option: null
              query: map_jinja.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja configuration: lookup 'map_jinja.yaml' with 'config.get'
          [DEBUG   ] map.jinja configuration: parsed matchers:
              - option: null
                query: map_jinja.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
          [DEBUG   ] map.jinja configuration: built-in configuration:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: final configuration values:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja: load parameters from sources:
          - Y:G@osarch
          - Y:G@os_family
          - Y:G@os
          - Y:G@osfinger
          - C@TEMPLATE:lookup
          - C@TEMPLATE
          - Y:G@id
          [DEBUG   ] map.jinja: process matcher: 'defaults.yaml'
          [DEBUG   ] map.jinja: use built-in defaults for matcher:
              option: null
              query: defaults.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja: lookup 'defaults.yaml' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osarch
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osarch' with 'grains.get'
          [DEBUG   ] Override  __grains__: <module 'salt.loaded.int.module.grains' from '/usr/lib/python3.8/site-packages/salt/modules/grains.py'>
          [DEBUG   ] LazyLoaded grains.get
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os_family
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os_family' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osfinger
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osfinger' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE:lookup
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE:lookup' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: id
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'id' with 'grains.get'
          [DEBUG   ] map.jinja: parsed matchers:
              - option: null
                query: defaults.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
              - option: G
                query: osarch
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: x86_64
              - option: G
                query: os_family
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: Suse
              - option: G
                query: os
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: SUSE
              - option: G
                query: osfinger
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: openSUSE Tumbleweed-20210824
              - option: C
                query: TEMPLATE:lookup
                query_delimiter: ':'
                query_method: config.get
                type: C
                value: &id001
           master: template-master
           winner: lookup
           added_in_lookup: lookup_value
              - option: C
                query: TEMPLATE
                query_delimiter: ':'
                query_method: config.get
                type: C
                value:
           lookup: *id001
           pkg:
             name: bash
           service:
             name: systemd-journald
           config: /etc/template-formula.conf
           tofs:
             files_switch:
             - any/path/can/be/used/here
             - id
             - roles
             - osfinger
             - os
             - os_family
             source_files:
               TEMPLATE-config-file-file-managed:
               - example.tmpl.jinja
               TEMPLATE-subcomponent-config-file-file-managed:
               - subcomponent-example.tmpl.jinja
           winner: pillar
           added_in_pillar: pillar_value
              - option: G
                query: id
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: 74230d4c8bf4
          [DEBUG   ] map.jinja: built-in configuration:
          values: {}
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/defaults.yaml:
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] LazyLoaded slsutil.merge
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/defaults.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/defaults.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/osarch/x86_64.yaml:
          values:
            arch: amd64
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/osarch/x86_64.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osarch/x86_64.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/os_family/Suse.yaml:
          values:
            pkg:
              name: TEMPLATE-suse
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/os_family/Suse.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE-suse
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os_family/Suse.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: merge 'TEMPLATE:lookup' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_lookup: lookup_value
          master: template-master
          winner: lookup
          [DEBUG   ] map.jinja: merge 'TEMPLATE' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_pillar: pillar_value
          config: /etc/template-formula.conf
          lookup:
            added_in_lookup: lookup_value
            master: template-master
            winner: lookup
          pkg:
            name: bash
          service:
            name: systemd-journald
          tofs:
            files_switch:
            - any/path/can/be/used/here
            - id
            - roles
            - osfinger
            - os
            - os_family
            source_files:
              TEMPLATE-config-file-file-managed:
              - example.tmpl.jinja
              TEMPLATE-subcomponent-config-file-file-managed:
              - subcomponent-example.tmpl.jinja
          winner: pillar
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: final configuration values:
          values:
            added_in_defaults: defaults_value
            added_in_lookup: lookup_value
            added_in_pillar: pillar_value
            arch: amd64
            config: /etc/template-formula.conf
            lookup:
              added_in_lookup: lookup_value
              master: template-master
              winner: lookup
            master: template-master
            pkg:
              name: bash
            rootgroup: root
            service:
              name: systemd-journald
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            tofs:
              files_switch:
              - any/path/can/be/used/here
              - id
              - roles
              - osfinger
              - os
              - os_family
              source_files:
                TEMPLATE-config-file-file-managed:
                - example.tmpl.jinja
                TEMPLATE-subcomponent-config-file-file-managed:
                - subcomponent-example.tmpl.jinja
            winner: pillar
          [DEBUG   ] map.jinja: save parameters in variable 'mapdata'
          [DEBUG   ] map.jinja: post-processing of 'mapdata'
          [DEBUG   ] Could not find file 'salt://TEMPLATE/post-map.jinja' in saltenv 'base'
          [DEBUG   ] ### MAP.JINJA DUMP ###
          values:
            added_in_defaults: defaults_value
            added_in_lookup: lookup_value
            added_in_pillar: pillar_value
            arch: amd64
            config: /etc/template-formula.conf
            lookup:
              added_in_lookup: lookup_value
              master: template-master
              winner: lookup
            map_jinja:
              sources:
              - Y:G@osarch
              - Y:G@os_family
              - Y:G@os
              - Y:G@osfinger
              - C@TEMPLATE:lookup
              - C@TEMPLATE
              - Y:G@id
            master: template-master
            pkg:
              name: bash
            rootgroup: root
            service:
              name: systemd-journald
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            tofs:
              files_switch:
              - any/path/can/be/used/here
              - id
              - roles
              - osfinger
              - os
              - os_family
              source_files:
                TEMPLATE-config-file-file-managed:
                - example.tmpl.jinja
                TEMPLATE-subcomponent-config-file-file-managed:
                - subcomponent-example.tmpl.jinja
            winner: pillar
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/_mapdata/init.sls' using 'jinja' renderer: 0.20116209983825684
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/_mapdata/init.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          ---
          
          TEMPLATE-mapdata-dump:
            file.managed:
              - name: /tmp/salt_mapdata_dump.yaml
              - source: salt://TEMPLATE/_mapdata/_mapdata.jinja
              - template: jinja
              - context:
           map: {values: {added_in_defaults: defaults_value, added_in_lookup: lookup_value, added_in_pillar: pillar_value,
              arch: amd64, config: /etc/template-formula.conf, lookup: {added_in_lookup: lookup_value,
                master: template-master, winner: lookup}, map_jinja: {sources: ['Y:G@osarch',
           'Y:G@os_family', 'Y:G@os', 'Y:G@osfinger', 'C@TEMPLATE:lookup', C@TEMPLATE,
           'Y:G@id']}, master: template-master, pkg: {name: bash}, rootgroup: root, service: {
                name: systemd-journald}, subcomponent: {config: /etc/TEMPLATE-subcomponent-formula.conf},
              tofs: {files_switch: [any/path/can/be/used/here, id, roles, osfinger, os, os_family],
                source_files: {TEMPLATE-config-file-file-managed: [example.tmpl.jinja], TEMPLATE-subcomponent-config-file-file-managed: [
             subcomponent-example.tmpl.jinja]}}, winner: pillar}}
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('TEMPLATE-mapdata-dump', OrderedDict([('file.managed', [OrderedDict([('name', '/tmp/salt_mapdata_dump.yaml')]), OrderedDict([('source', 'salt://TEMPLATE/_mapdata/_mapdata.jinja')]), OrderedDict([('template', 'jinja')]), OrderedDict([('context', OrderedDict([('map', OrderedDict([('values', OrderedDict([('added_in_defaults', 'defaults_value'), ('added_in_lookup', 'lookup_value'), ('added_in_pillar', 'pillar_value'), ('arch', 'amd64'), ('config', '/etc/template-formula.conf'), ('lookup', OrderedDict([('added_in_lookup', 'lookup_value'), ('master', 'template-master'), ('winner', 'lookup')])), ('map_jinja', OrderedDict([('sources', ['Y:G@osarch', 'Y:G@os_family', 'Y:G@os', 'Y:G@osfinger', 'C@TEMPLATE:lookup', 'C@TEMPLATE', 'Y:G@id'])])), ('master', 'template-master'), ('pkg', OrderedDict([('name', 'bash')])), ('rootgroup', 'root'), ('service', OrderedDict([('name', 'systemd-journald')])), ('subcomponent', OrderedDict([('config', '/etc/TEMPLATE-subcomponent-formula.conf')])), ('tofs', OrderedDict([('files_switch', ['any/path/can/be/used/here', 'id', 'roles', 'osfinger', 'os', 'os_family']), ('source_files', OrderedDict([('TEMPLATE-config-file-file-managed', ['example.tmpl.jinja']), ('TEMPLATE-subcomponent-config-file-file-managed', ['subcomponent-example.tmpl.jinja'])]))])), ('winner', 'pillar')]))]))]))])])]))])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/_mapdata/init.sls' using 'yaml' renderer: 0.0012710094451904297
          [DEBUG   ] Could not find file 'salt://TEMPLATE.sls' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/init.sls' to resolve 'salt://TEMPLATE/init.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/init.sls' to resolve 'salt://TEMPLATE/init.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/init.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/init.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/init.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/init.sls' using 'jinja' renderer: 0.0011744499206542969
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/init.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - .package
            - .config
            - .service
            - .subcomponent
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['.package', '.config', '.service', '.subcomponent'])])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/init.sls' using 'yaml' renderer: 0.0005259513854980469
          [DEBUG   ] Could not find file 'salt://TEMPLATE/package.sls' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/package/init.sls' to resolve 'salt://TEMPLATE/package/init.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/init.sls' to resolve 'salt://TEMPLATE/package/init.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/package/init.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/package/init.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/init.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/init.sls' using 'jinja' renderer: 0.0010902881622314453
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/init.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - .install
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['.install'])])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/init.sls' using 'yaml' renderer: 0.00046563148498535156
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/package/install.sls' to resolve 'salt://TEMPLATE/package/install.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/install.sls' to resolve 'salt://TEMPLATE/package/install.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/package/install.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/package/install.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/install.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] [libsaltcli] the salt command type has been identified to be: local
          [DEBUG   ] map.jinja configuration: process matcher: 'map_jinja.yaml'
          [DEBUG   ] map.jinja configuration: use built-in defaults for matcher:
              option: null
              query: map_jinja.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja configuration: lookup 'map_jinja.yaml' with 'config.get'
          [DEBUG   ] map.jinja configuration: parsed matchers:
              - option: null
                query: map_jinja.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
          [DEBUG   ] map.jinja configuration: built-in configuration:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: final configuration values:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja: load parameters from sources:
          - Y:G@osarch
          - Y:G@os_family
          - Y:G@os
          - Y:G@osfinger
          - C@TEMPLATE:lookup
          - C@TEMPLATE
          - Y:G@id
          [DEBUG   ] map.jinja: process matcher: 'defaults.yaml'
          [DEBUG   ] map.jinja: use built-in defaults for matcher:
              option: null
              query: defaults.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja: lookup 'defaults.yaml' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osarch
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osarch' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os_family
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os_family' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osfinger
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osfinger' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE:lookup
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE:lookup' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: id
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'id' with 'grains.get'
          [DEBUG   ] map.jinja: parsed matchers:
              - option: null
                query: defaults.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
              - option: G
                query: osarch
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: x86_64
              - option: G
                query: os_family
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: Suse
              - option: G
                query: os
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: SUSE
              - option: G
                query: osfinger
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: openSUSE Tumbleweed-20210824
              - option: C
                query: TEMPLATE:lookup
                query_delimiter: ':'
                query_method: config.get
                type: C
                value: &id001
           master: template-master
           winner: lookup
           added_in_lookup: lookup_value
              - option: C
                query: TEMPLATE
                query_delimiter: ':'
                query_method: config.get
                type: C
                value:
           lookup: *id001
           pkg:
             name: bash
           service:
             name: systemd-journald
           config: /etc/template-formula.conf
           tofs:
             files_switch:
             - any/path/can/be/used/here
             - id
             - roles
             - osfinger
             - os
             - os_family
             source_files:
               TEMPLATE-config-file-file-managed:
               - example.tmpl.jinja
               TEMPLATE-subcomponent-config-file-file-managed:
               - subcomponent-example.tmpl.jinja
           winner: pillar
           added_in_pillar: pillar_value
              - option: G
                query: id
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: 74230d4c8bf4
          [DEBUG   ] map.jinja: built-in configuration:
          values: {}
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/defaults.yaml:
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/defaults.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/defaults.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/osarch/x86_64.yaml:
          values:
            arch: amd64
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/osarch/x86_64.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osarch/x86_64.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/os_family/Suse.yaml:
          values:
            pkg:
              name: TEMPLATE-suse
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/os_family/Suse.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE-suse
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os_family/Suse.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: merge 'TEMPLATE:lookup' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_lookup: lookup_value
          master: template-master
          winner: lookup
          [DEBUG   ] map.jinja: merge 'TEMPLATE' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_pillar: pillar_value
          config: /etc/template-formula.conf
          lookup:
            added_in_lookup: lookup_value
            master: template-master
            winner: lookup
          pkg:
            name: bash
          service:
            name: systemd-journald
          tofs:
            files_switch:
            - any/path/can/be/used/here
            - id
            - roles
            - osfinger
            - os
            - os_family
            source_files:
              TEMPLATE-config-file-file-managed:
              - example.tmpl.jinja
              TEMPLATE-subcomponent-config-file-file-managed:
              - subcomponent-example.tmpl.jinja
          winner: pillar
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: final configuration values:
          values:
            added_in_defaults: defaults_value
            added_in_lookup: lookup_value
            added_in_pillar: pillar_value
            arch: amd64
            config: /etc/template-formula.conf
            lookup:
              added_in_lookup: lookup_value
              master: template-master
              winner: lookup
            master: template-master
            pkg:
              name: bash
            rootgroup: root
            service:
              name: systemd-journald
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            tofs:
              files_switch:
              - any/path/can/be/used/here
              - id
              - roles
              - osfinger
              - os
              - os_family
              source_files:
                TEMPLATE-config-file-file-managed:
                - example.tmpl.jinja
                TEMPLATE-subcomponent-config-file-file-managed:
                - subcomponent-example.tmpl.jinja
            winner: pillar
          [DEBUG   ] map.jinja: save parameters in variable 'mapdata'
          [DEBUG   ] map.jinja: post-processing of 'mapdata'
          [DEBUG   ] Could not find file 'salt://TEMPLATE/post-map.jinja' in saltenv 'base'
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/install.sls' using 'jinja' renderer: 0.17313170433044434
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/install.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          TEMPLATE-package-install-pkg-installed:
            pkg.installed:
              - name: bash
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('TEMPLATE-package-install-pkg-installed', OrderedDict([('pkg.installed', [OrderedDict([('name', 'bash')])])]))])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/package/install.sls' using 'yaml' renderer: 0.0005795955657958984
          [DEBUG   ] Could not find file 'salt://TEMPLATE/config.sls' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/config/init.sls' to resolve 'salt://TEMPLATE/config/init.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/init.sls' to resolve 'salt://TEMPLATE/config/init.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/config/init.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/config/init.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/init.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/init.sls' using 'jinja' renderer: 0.001177072525024414
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/init.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - .file
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['.file'])])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/init.sls' using 'yaml' renderer: 0.0004856586456298828
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/config/file.sls' to resolve 'salt://TEMPLATE/config/file.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/file.sls' to resolve 'salt://TEMPLATE/config/file.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/config/file.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/config/file.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/file.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] [libsaltcli] the salt command type has been identified to be: local
          [DEBUG   ] map.jinja configuration: process matcher: 'map_jinja.yaml'
          [DEBUG   ] map.jinja configuration: use built-in defaults for matcher:
              option: null
              query: map_jinja.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja configuration: lookup 'map_jinja.yaml' with 'config.get'
          [DEBUG   ] map.jinja configuration: parsed matchers:
              - option: null
                query: map_jinja.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
          [DEBUG   ] map.jinja configuration: built-in configuration:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: final configuration values:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja: load parameters from sources:
          - Y:G@osarch
          - Y:G@os_family
          - Y:G@os
          - Y:G@osfinger
          - C@TEMPLATE:lookup
          - C@TEMPLATE
          - Y:G@id
          [DEBUG   ] map.jinja: process matcher: 'defaults.yaml'
          [DEBUG   ] map.jinja: use built-in defaults for matcher:
              option: null
              query: defaults.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja: lookup 'defaults.yaml' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osarch
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osarch' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os_family
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os_family' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osfinger
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osfinger' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE:lookup
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE:lookup' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: id
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'id' with 'grains.get'
          [DEBUG   ] map.jinja: parsed matchers:
              - option: null
                query: defaults.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
              - option: G
                query: osarch
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: x86_64
              - option: G
                query: os_family
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: Suse
              - option: G
                query: os
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: SUSE
              - option: G
                query: osfinger
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: openSUSE Tumbleweed-20210824
              - option: C
                query: TEMPLATE:lookup
                query_delimiter: ':'
                query_method: config.get
                type: C
                value: &id001
           master: template-master
           winner: lookup
           added_in_lookup: lookup_value
              - option: C
                query: TEMPLATE
                query_delimiter: ':'
                query_method: config.get
                type: C
                value:
           lookup: *id001
           pkg:
             name: bash
           service:
             name: systemd-journald
           config: /etc/template-formula.conf
           tofs:
             files_switch:
             - any/path/can/be/used/here
             - id
             - roles
             - osfinger
             - os
             - os_family
             source_files:
               TEMPLATE-config-file-file-managed:
               - example.tmpl.jinja
               TEMPLATE-subcomponent-config-file-file-managed:
               - subcomponent-example.tmpl.jinja
           winner: pillar
           added_in_pillar: pillar_value
              - option: G
                query: id
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: 74230d4c8bf4
          [DEBUG   ] map.jinja: built-in configuration:
          values: {}
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/defaults.yaml:
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/defaults.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/defaults.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/osarch/x86_64.yaml:
          values:
            arch: amd64
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/osarch/x86_64.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osarch/x86_64.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/os_family/Suse.yaml:
          values:
            pkg:
              name: TEMPLATE-suse
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/os_family/Suse.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE-suse
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os_family/Suse.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: merge 'TEMPLATE:lookup' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_lookup: lookup_value
          master: template-master
          winner: lookup
          [DEBUG   ] map.jinja: merge 'TEMPLATE' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_pillar: pillar_value
          config: /etc/template-formula.conf
          lookup:
            added_in_lookup: lookup_value
            master: template-master
            winner: lookup
          pkg:
            name: bash
          service:
            name: systemd-journald
          tofs:
            files_switch:
            - any/path/can/be/used/here
            - id
            - roles
            - osfinger
            - os
            - os_family
            source_files:
              TEMPLATE-config-file-file-managed:
              - example.tmpl.jinja
              TEMPLATE-subcomponent-config-file-file-managed:
              - subcomponent-example.tmpl.jinja
          winner: pillar
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: final configuration values:
          values:
            added_in_defaults: defaults_value
            added_in_lookup: lookup_value
            added_in_pillar: pillar_value
            arch: amd64
            config: /etc/template-formula.conf
            lookup:
              added_in_lookup: lookup_value
              master: template-master
              winner: lookup
            master: template-master
            pkg:
              name: bash
            rootgroup: root
            service:
              name: systemd-journald
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            tofs:
              files_switch:
              - any/path/can/be/used/here
              - id
              - roles
              - osfinger
              - os
              - os_family
              source_files:
                TEMPLATE-config-file-file-managed:
                - example.tmpl.jinja
                TEMPLATE-subcomponent-config-file-file-managed:
                - subcomponent-example.tmpl.jinja
            winner: pillar
          [DEBUG   ] map.jinja: save parameters in variable 'mapdata'
          [DEBUG   ] map.jinja: post-processing of 'mapdata'
          [DEBUG   ] Could not find file 'salt://TEMPLATE/post-map.jinja' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libtofs.jinja' to resolve 'salt://TEMPLATE/libtofs.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libtofs.jinja' to resolve 'salt://TEMPLATE/libtofs.jinja'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/libtofs.jinja'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/libtofs.jinja'
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/file.sls' using 'jinja' renderer: 0.20836853981018066
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/file.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - TEMPLATE.package.install
          
          TEMPLATE-config-file-file-managed:
            file.managed:
              - name: /etc/template-formula.conf
              - source: 
                - salt://TEMPLATE/files/any/path/can/be/used/here/example.tmpl.jinja
                - salt://TEMPLATE/files/any/path/can/be/used/here/example.tmpl
                - salt://TEMPLATE/files/74230d4c8bf4/example.tmpl.jinja
                - salt://TEMPLATE/files/74230d4c8bf4/example.tmpl
                - salt://TEMPLATE/files/foo/example.tmpl.jinja
                - salt://TEMPLATE/files/bar/example.tmpl.jinja
                - salt://TEMPLATE/files/foo/example.tmpl
                - salt://TEMPLATE/files/bar/example.tmpl
                - salt://TEMPLATE/files/openSUSE Tumbleweed-20210824/example.tmpl.jinja
                - salt://TEMPLATE/files/openSUSE Tumbleweed-20210824/example.tmpl
                - salt://TEMPLATE/files/SUSE/example.tmpl.jinja
                - salt://TEMPLATE/files/SUSE/example.tmpl
                - salt://TEMPLATE/files/Suse/example.tmpl.jinja
                - salt://TEMPLATE/files/Suse/example.tmpl
                - salt://TEMPLATE/files/default/example.tmpl.jinja
                - salt://TEMPLATE/files/default/example.tmpl
              - mode: 644
              - user: root
              - group: root
              - makedirs: True
              - template: jinja
              - require:
                - sls: TEMPLATE.package.install
              - context:
           TEMPLATE: {"added_in_defaults": "defaults_value", "added_in_lookup": "lookup_value", "added_in_pillar": "pillar_value", "arch": "amd64", "config": "/etc/template-formula.conf", "lookup": {"added_in_lookup": "lookup_value", "master": "template-master", "winner": "lookup"}, "map_jinja": {"sources": ["Y:G@osarch", "Y:G@os_family", "Y:G@os", "Y:G@osfinger", "C@TEMPLATE:lookup", "C@TEMPLATE", "Y:G@id"]}, "master": "template-master", "pkg": {"name": "bash"}, "rootgroup": "root", "service": {"name": "systemd-journald"}, "subcomponent": {"config": "/etc/TEMPLATE-subcomponent-formula.conf"}, "tofs": {"files_switch": ["any/path/can/be/used/here", "id", "roles", "osfinger", "os", "os_family"], "source_files": {"TEMPLATE-config-file-file-managed": ["example.tmpl.jinja"], "TEMPLATE-subcomponent-config-file-file-managed": ["subcomponent-example.tmpl.jinja"]}}, "winner": "pillar"}
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['TEMPLATE.package.install']), ('TEMPLATE-config-file-file-managed', OrderedDict([('file.managed', [OrderedDict([('name', '/etc/template-formula.conf')]), OrderedDict([('source', ['salt://TEMPLATE/files/any/path/can/be/used/here/example.tmpl.jinja', 'salt://TEMPLATE/files/any/path/can/be/used/here/example.tmpl', 'salt://TEMPLATE/files/74230d4c8bf4/example.tmpl.jinja', 'salt://TEMPLATE/files/74230d4c8bf4/example.tmpl', 'salt://TEMPLATE/files/foo/example.tmpl.jinja', 'salt://TEMPLATE/files/bar/example.tmpl.jinja', 'salt://TEMPLATE/files/foo/example.tmpl', 'salt://TEMPLATE/files/bar/example.tmpl', 'salt://TEMPLATE/files/openSUSE Tumbleweed-20210824/example.tmpl.jinja', 'salt://TEMPLATE/files/openSUSE Tumbleweed-20210824/example.tmpl', 'salt://TEMPLATE/files/SUSE/example.tmpl.jinja', 'salt://TEMPLATE/files/SUSE/example.tmpl', 'salt://TEMPLATE/files/Suse/example.tmpl.jinja', 'salt://TEMPLATE/files/Suse/example.tmpl', 'salt://TEMPLATE/files/default/example.tmpl.jinja', 'salt://TEMPLATE/files/default/example.tmpl'])]), OrderedDict([('mode', 644)]), OrderedDict([('user', 'root')]), OrderedDict([('group', 'root')]), OrderedDict([('makedirs', True)]), OrderedDict([('template', 'jinja')]), OrderedDict([('require', [OrderedDict([('sls', 'TEMPLATE.package.install')])])]), OrderedDict([('context', OrderedDict([('TEMPLATE', OrderedDict([('added_in_defaults', 'defaults_value'), ('added_in_lookup', 'lookup_value'), ('added_in_pillar', 'pillar_value'), ('arch', 'amd64'), ('config', '/etc/template-formula.conf'), ('lookup', OrderedDict([('added_in_lookup', 'lookup_value'), ('master', 'template-master'), ('winner', 'lookup')])), ('map_jinja', OrderedDict([('sources', ['Y:G@osarch', 'Y:G@os_family', 'Y:G@os', 'Y:G@osfinger', 'C@TEMPLATE:lookup', 'C@TEMPLATE', 'Y:G@id'])])), ('master', 'template-master'), ('pkg', OrderedDict([('name', 'bash')])), ('rootgroup', 'root'), ('service', OrderedDict([('name', 'systemd-journald')])), ('subcomponent', OrderedDict([('config', '/etc/TEMPLATE-subcomponent-formula.conf')])), ('tofs', OrderedDict([('files_switch', ['any/path/can/be/used/here', 'id', 'roles', 'osfinger', 'os', 'os_family']), ('source_files', OrderedDict([('TEMPLATE-config-file-file-managed', ['example.tmpl.jinja']), ('TEMPLATE-subcomponent-config-file-file-managed', ['subcomponent-example.tmpl.jinja'])]))])), ('winner', 'pillar')]))]))])])]))])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/config/file.sls' using 'yaml' renderer: 0.0016467571258544922
          [DEBUG   ] Could not find file 'salt://TEMPLATE/service.sls' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/service/init.sls' to resolve 'salt://TEMPLATE/service/init.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/init.sls' to resolve 'salt://TEMPLATE/service/init.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/service/init.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/service/init.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/init.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/init.sls' using 'jinja' renderer: 0.0011754035949707031
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/init.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - .running
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['.running'])])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/init.sls' using 'yaml' renderer: 0.0005052089691162109
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/service/running.sls' to resolve 'salt://TEMPLATE/service/running.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/running.sls' to resolve 'salt://TEMPLATE/service/running.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/service/running.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/service/running.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/running.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] [libsaltcli] the salt command type has been identified to be: local
          [DEBUG   ] map.jinja configuration: process matcher: 'map_jinja.yaml'
          [DEBUG   ] map.jinja configuration: use built-in defaults for matcher:
              option: null
              query: map_jinja.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja configuration: lookup 'map_jinja.yaml' with 'config.get'
          [DEBUG   ] map.jinja configuration: parsed matchers:
              - option: null
                query: map_jinja.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
          [DEBUG   ] map.jinja configuration: built-in configuration:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: final configuration values:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja: load parameters from sources:
          - Y:G@osarch
          - Y:G@os_family
          - Y:G@os
          - Y:G@osfinger
          - C@TEMPLATE:lookup
          - C@TEMPLATE
          - Y:G@id
          [DEBUG   ] map.jinja: process matcher: 'defaults.yaml'
          [DEBUG   ] map.jinja: use built-in defaults for matcher:
              option: null
              query: defaults.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja: lookup 'defaults.yaml' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osarch
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osarch' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os_family
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os_family' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osfinger
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osfinger' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE:lookup
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE:lookup' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: id
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'id' with 'grains.get'
          [DEBUG   ] map.jinja: parsed matchers:
              - option: null
                query: defaults.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
              - option: G
                query: osarch
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: x86_64
              - option: G
                query: os_family
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: Suse
              - option: G
                query: os
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: SUSE
              - option: G
                query: osfinger
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: openSUSE Tumbleweed-20210824
              - option: C
                query: TEMPLATE:lookup
                query_delimiter: ':'
                query_method: config.get
                type: C
                value: &id001
           master: template-master
           winner: lookup
           added_in_lookup: lookup_value
              - option: C
                query: TEMPLATE
                query_delimiter: ':'
                query_method: config.get
                type: C
                value:
           lookup: *id001
           pkg:
             name: bash
           service:
             name: systemd-journald
           config: /etc/template-formula.conf
           tofs:
             files_switch:
             - any/path/can/be/used/here
             - id
             - roles
             - osfinger
             - os
             - os_family
             source_files:
               TEMPLATE-config-file-file-managed:
               - example.tmpl.jinja
               TEMPLATE-subcomponent-config-file-file-managed:
               - subcomponent-example.tmpl.jinja
           winner: pillar
           added_in_pillar: pillar_value
              - option: G
                query: id
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: 74230d4c8bf4
          [DEBUG   ] map.jinja: built-in configuration:
          values: {}
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/defaults.yaml:
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/defaults.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/defaults.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/osarch/x86_64.yaml:
          values:
            arch: amd64
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/osarch/x86_64.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osarch/x86_64.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/os_family/Suse.yaml:
          values:
            pkg:
              name: TEMPLATE-suse
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/os_family/Suse.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE-suse
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os_family/Suse.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: merge 'TEMPLATE:lookup' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_lookup: lookup_value
          master: template-master
          winner: lookup
          [DEBUG   ] map.jinja: merge 'TEMPLATE' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_pillar: pillar_value
          config: /etc/template-formula.conf
          lookup:
            added_in_lookup: lookup_value
            master: template-master
            winner: lookup
          pkg:
            name: bash
          service:
            name: systemd-journald
          tofs:
            files_switch:
            - any/path/can/be/used/here
            - id
            - roles
            - osfinger
            - os
            - os_family
            source_files:
              TEMPLATE-config-file-file-managed:
              - example.tmpl.jinja
              TEMPLATE-subcomponent-config-file-file-managed:
              - subcomponent-example.tmpl.jinja
          winner: pillar
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: final configuration values:
          values:
            added_in_defaults: defaults_value
            added_in_lookup: lookup_value
            added_in_pillar: pillar_value
            arch: amd64
            config: /etc/template-formula.conf
            lookup:
              added_in_lookup: lookup_value
              master: template-master
              winner: lookup
            master: template-master
            pkg:
              name: bash
            rootgroup: root
            service:
              name: systemd-journald
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            tofs:
              files_switch:
              - any/path/can/be/used/here
              - id
              - roles
              - osfinger
              - os
              - os_family
              source_files:
                TEMPLATE-config-file-file-managed:
                - example.tmpl.jinja
                TEMPLATE-subcomponent-config-file-file-managed:
                - subcomponent-example.tmpl.jinja
            winner: pillar
          [DEBUG   ] map.jinja: save parameters in variable 'mapdata'
          [DEBUG   ] map.jinja: post-processing of 'mapdata'
          [DEBUG   ] Could not find file 'salt://TEMPLATE/post-map.jinja' in saltenv 'base'
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/running.sls' using 'jinja' renderer: 0.1733989715576172
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/running.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - TEMPLATE.config.file
          
          TEMPLATE-service-running-service-running:
            service.running:
              - name: systemd-journald
              - enable: True
              - watch:
                - sls: TEMPLATE.config.file
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['TEMPLATE.config.file']), ('TEMPLATE-service-running-service-running', OrderedDict([('service.running', [OrderedDict([('name', 'systemd-journald')]), OrderedDict([('enable', True)]), OrderedDict([('watch', [OrderedDict([('sls', 'TEMPLATE.config.file')])])])])]))])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/service/running.sls' using 'yaml' renderer: 0.0007331371307373047
          [DEBUG   ] Could not find file 'salt://TEMPLATE/subcomponent.sls' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/subcomponent/init.sls' to resolve 'salt://TEMPLATE/subcomponent/init.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/init.sls' to resolve 'salt://TEMPLATE/subcomponent/init.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/subcomponent/init.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/subcomponent/init.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/init.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/init.sls' using 'jinja' renderer: 0.0012111663818359375
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/init.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - .config
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['.config'])])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/init.sls' using 'yaml' renderer: 0.0004963874816894531
          [DEBUG   ] Could not find file 'salt://TEMPLATE/subcomponent/config.sls' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/subcomponent/config/init.sls' to resolve 'salt://TEMPLATE/subcomponent/config/init.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/init.sls' to resolve 'salt://TEMPLATE/subcomponent/config/init.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/subcomponent/config/init.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/subcomponent/config/init.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/init.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/init.sls' using 'jinja' renderer: 0.0011403560638427734
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/init.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - .file
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['.file'])])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/init.sls' using 'yaml' renderer: 0.00046753883361816406
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/subcomponent/config/file.sls' to resolve 'salt://TEMPLATE/subcomponent/config/file.sls'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/file.sls' to resolve 'salt://TEMPLATE/subcomponent/config/file.sls'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/subcomponent/config/file.sls'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/subcomponent/config/file.sls'
          [DEBUG   ] compile template: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/file.sls
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/map.jinja' to resolve 'salt://TEMPLATE/map.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmapstack.jinja' to resolve 'salt://TEMPLATE/libmapstack.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libmatchers.jinja' to resolve 'salt://TEMPLATE/libmatchers.jinja'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libsaltcli.jinja' to resolve 'salt://TEMPLATE/libsaltcli.jinja'
          [DEBUG   ] [libsaltcli] the salt command type has been identified to be: local
          [DEBUG   ] map.jinja configuration: process matcher: 'map_jinja.yaml'
          [DEBUG   ] map.jinja configuration: use built-in defaults for matcher:
              option: null
              query: map_jinja.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja configuration: lookup 'map_jinja.yaml' with 'config.get'
          [DEBUG   ] map.jinja configuration: parsed matchers:
              - option: null
                query: map_jinja.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
          [DEBUG   ] map.jinja configuration: built-in configuration:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: load configuration values from TEMPLATE/parameters/map_jinja.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/map_jinja.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja configuration: final configuration values:
          values:
            sources:
            - Y:G@osarch
            - Y:G@os_family
            - Y:G@os
            - Y:G@osfinger
            - C@TEMPLATE:lookup
            - C@TEMPLATE
            - Y:G@id
          [DEBUG   ] map.jinja: load parameters from sources:
          - Y:G@osarch
          - Y:G@os_family
          - Y:G@os
          - Y:G@osfinger
          - C@TEMPLATE:lookup
          - C@TEMPLATE
          - Y:G@id
          [DEBUG   ] map.jinja: process matcher: 'defaults.yaml'
          [DEBUG   ] map.jinja: use built-in defaults for matcher:
              option: null
              query: defaults.yaml
              query_delimiter: ':'
              query_method: config.get
              type: F
          [DEBUG   ] map.jinja: lookup 'defaults.yaml' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osarch'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osarch
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osarch' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os_family'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os_family
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os_family' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@os'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: os
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'os' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@osfinger'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: osfinger
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'osfinger' with 'grains.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE:lookup'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE:lookup
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE:lookup' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse matcher: 'C@TEMPLATE'
          [DEBUG   ] map.jinja: parse as 1 metadata matcher:
              option: C
              query: TEMPLATE
              query_delimiter: ':'
              type: C
          [DEBUG   ] map.jinja: lookup 'TEMPLATE' with 'config.get'
          [DEBUG   ] map.jinja: process matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse matcher: 'Y:G@id'
          [DEBUG   ] map.jinja: parse as 2 metadata matcher:
              option: G
              query: id
              query_delimiter: ':'
              type: Y
          [DEBUG   ] map.jinja: lookup 'id' with 'grains.get'
          [DEBUG   ] map.jinja: parsed matchers:
              - option: null
                query: defaults.yaml
                query_delimiter: ':'
                query_method: config.get
                type: F
                value: []
              - option: G
                query: osarch
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: x86_64
              - option: G
                query: os_family
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: Suse
              - option: G
                query: os
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: SUSE
              - option: G
                query: osfinger
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: openSUSE Tumbleweed-20210824
              - option: C
                query: TEMPLATE:lookup
                query_delimiter: ':'
                query_method: config.get
                type: C
                value: &id001
           master: template-master
           winner: lookup
           added_in_lookup: lookup_value
              - option: C
                query: TEMPLATE
                query_delimiter: ':'
                query_method: config.get
                type: C
                value:
           lookup: *id001
           pkg:
             name: bash
           service:
             name: systemd-journald
           config: /etc/template-formula.conf
           tofs:
             files_switch:
             - any/path/can/be/used/here
             - id
             - roles
             - osfinger
             - os
             - os_family
             source_files:
               TEMPLATE-config-file-file-managed:
               - example.tmpl.jinja
               TEMPLATE-subcomponent-config-file-file-managed:
               - subcomponent-example.tmpl.jinja
           winner: pillar
           added_in_pillar: pillar_value
              - option: G
                query: id
                query_delimiter: ':'
                query_method: grains.get
                type: Y
                value: 74230d4c8bf4
          [DEBUG   ] map.jinja: built-in configuration:
          values: {}
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/defaults.yaml' to resolve 'salt://TEMPLATE/parameters/defaults.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/defaults.yaml:
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/defaults.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/defaults.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/defaults.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/osarch/x86_64.yaml' to resolve 'salt://TEMPLATE/parameters/osarch/x86_64.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/osarch/x86_64.yaml:
          values:
            arch: amd64
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/osarch/x86_64.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osarch/x86_64.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osarch/x86_64.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/parameters/os_family/Suse.yaml' to resolve 'salt://TEMPLATE/parameters/os_family/Suse.yaml'
          [DEBUG   ] map.jinja: loaded configuration values from TEMPLATE/parameters/os_family/Suse.yaml:
          values:
            pkg:
              name: TEMPLATE-suse
          [DEBUG   ] map.jinja: merged configuration values from TEMPLATE/parameters/os_family/Suse.yaml, merge: strategy='smart', merge_lists='False':
          values:
            added_in_defaults: defaults_value
            arch: amd64
            config: /etc/TEMPLATE
            pkg:
              name: TEMPLATE-suse
            rootgroup: root
            service:
              name: TEMPLATE
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            winner: defaults
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os_family/Suse.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os_family/Suse.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/os/SUSE.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/os/SUSE.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/osfinger/openSUSE Tumbleweed-20210824.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: merge 'TEMPLATE:lookup' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_lookup: lookup_value
          master: template-master
          winner: lookup
          [DEBUG   ] map.jinja: merge 'TEMPLATE' retrieved with 'config.get', merge: strategy='smart', lists='False':
          added_in_pillar: pillar_value
          config: /etc/template-formula.conf
          lookup:
            added_in_lookup: lookup_value
            master: template-master
            winner: lookup
          pkg:
            name: bash
          service:
            name: systemd-journald
          tofs:
            files_switch:
            - any/path/can/be/used/here
            - id
            - roles
            - osfinger
            - os
            - os_family
            source_files:
              TEMPLATE-config-file-file-managed:
              - example.tmpl.jinja
              TEMPLATE-subcomponent-config-file-file-managed:
              - subcomponent-example.tmpl.jinja
          winner: pillar
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml' in saltenv 'base'
          [DEBUG   ] map.jinja: load configuration values from TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja
          [DEBUG   ] Could not find file 'salt://TEMPLATE/parameters/id/74230d4c8bf4.yaml.jinja' in saltenv 'base'
          [DEBUG   ] map.jinja: final configuration values:
          values:
            added_in_defaults: defaults_value
            added_in_lookup: lookup_value
            added_in_pillar: pillar_value
            arch: amd64
            config: /etc/template-formula.conf
            lookup:
              added_in_lookup: lookup_value
              master: template-master
              winner: lookup
            master: template-master
            pkg:
              name: bash
            rootgroup: root
            service:
              name: systemd-journald
            subcomponent:
              config: /etc/TEMPLATE-subcomponent-formula.conf
            tofs:
              files_switch:
              - any/path/can/be/used/here
              - id
              - roles
              - osfinger
              - os
              - os_family
              source_files:
                TEMPLATE-config-file-file-managed:
                - example.tmpl.jinja
                TEMPLATE-subcomponent-config-file-file-managed:
                - subcomponent-example.tmpl.jinja
            winner: pillar
          [DEBUG   ] map.jinja: save parameters in variable 'mapdata'
          [DEBUG   ] map.jinja: post-processing of 'mapdata'
          [DEBUG   ] Could not find file 'salt://TEMPLATE/post-map.jinja' in saltenv 'base'
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/libtofs.jinja' to resolve 'salt://TEMPLATE/libtofs.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/libtofs.jinja' to resolve 'salt://TEMPLATE/libtofs.jinja'
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/file.sls' using 'jinja' renderer: 0.20863080024719238
          [DEBUG   ] Rendered data from file: /tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/file.sls:
          # -*- coding: utf-8 -*-
          # vim: ft=sls
          
          include:
            - TEMPLATE.config.file
          
          TEMPLATE-subcomponent-config-file-file-managed:
            file.managed:
              - name: /etc/TEMPLATE-subcomponent-formula.conf
              - source: 
                - salt://TEMPLATE/subcomponent/config/files/any/path/can/be/used/here/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/config/files/any/path/can/be/used/here/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/config/files/74230d4c8bf4/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/config/files/74230d4c8bf4/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/config/files/foo/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/config/files/bar/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/config/files/foo/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/config/files/bar/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/config/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/config/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/config/files/SUSE/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/config/files/SUSE/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/config/files/Suse/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/config/files/Suse/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/files/any/path/can/be/used/here/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/files/any/path/can/be/used/here/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/files/74230d4c8bf4/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/files/74230d4c8bf4/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/files/foo/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/files/bar/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/files/foo/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/files/bar/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/files/SUSE/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/files/SUSE/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/files/Suse/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/files/Suse/subcomponent-example.tmpl
                - salt://TEMPLATE/subcomponent/files/default/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/subcomponent/files/default/subcomponent-example.tmpl
                - salt://TEMPLATE/files/any/path/can/be/used/here/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/files/any/path/can/be/used/here/subcomponent-example.tmpl
                - salt://TEMPLATE/files/74230d4c8bf4/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/files/74230d4c8bf4/subcomponent-example.tmpl
                - salt://TEMPLATE/files/foo/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/files/bar/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/files/foo/subcomponent-example.tmpl
                - salt://TEMPLATE/files/bar/subcomponent-example.tmpl
                - salt://TEMPLATE/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl
                - salt://TEMPLATE/files/SUSE/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/files/SUSE/subcomponent-example.tmpl
                - salt://TEMPLATE/files/Suse/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/files/Suse/subcomponent-example.tmpl
                - salt://TEMPLATE/files/default/subcomponent-example.tmpl.jinja
                - salt://TEMPLATE/files/default/subcomponent-example.tmpl
              - mode: 644
              - user: root
              - group: root
              - makedirs: True
              - template: jinja
              - require_in:
                - sls: TEMPLATE.config.file
          
          [DEBUG   ] Results of YAML rendering: 
          OrderedDict([('include', ['TEMPLATE.config.file']), ('TEMPLATE-subcomponent-config-file-file-managed', OrderedDict([('file.managed', [OrderedDict([('name', '/etc/TEMPLATE-subcomponent-formula.conf')]), OrderedDict([('source', ['salt://TEMPLATE/subcomponent/config/files/any/path/can/be/used/here/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/config/files/any/path/can/be/used/here/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/config/files/74230d4c8bf4/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/config/files/74230d4c8bf4/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/config/files/foo/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/config/files/bar/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/config/files/foo/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/config/files/bar/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/config/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/config/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/config/files/SUSE/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/config/files/SUSE/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/config/files/Suse/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/config/files/Suse/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/files/any/path/can/be/used/here/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/files/any/path/can/be/used/here/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/files/74230d4c8bf4/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/files/74230d4c8bf4/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/files/foo/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/files/bar/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/files/foo/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/files/bar/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/files/SUSE/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/files/SUSE/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/files/Suse/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/files/Suse/subcomponent-example.tmpl', 'salt://TEMPLATE/subcomponent/files/default/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/subcomponent/files/default/subcomponent-example.tmpl', 'salt://TEMPLATE/files/any/path/can/be/used/here/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/files/any/path/can/be/used/here/subcomponent-example.tmpl', 'salt://TEMPLATE/files/74230d4c8bf4/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/files/74230d4c8bf4/subcomponent-example.tmpl', 'salt://TEMPLATE/files/foo/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/files/bar/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/files/foo/subcomponent-example.tmpl', 'salt://TEMPLATE/files/bar/subcomponent-example.tmpl', 'salt://TEMPLATE/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/files/openSUSE Tumbleweed-20210824/subcomponent-example.tmpl', 'salt://TEMPLATE/files/SUSE/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/files/SUSE/subcomponent-example.tmpl', 'salt://TEMPLATE/files/Suse/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/files/Suse/subcomponent-example.tmpl', 'salt://TEMPLATE/files/default/subcomponent-example.tmpl.jinja', 'salt://TEMPLATE/files/default/subcomponent-example.tmpl'])]), OrderedDict([('mode', 644)]), OrderedDict([('user', 'root')]), OrderedDict([('group', 'root')]), OrderedDict([('makedirs', True)]), OrderedDict([('template', 'jinja')]), OrderedDict([('require_in', [OrderedDict([('sls', 'TEMPLATE.config.file')])])])])]))])
          [PROFILE ] Time (in seconds) to render '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/file.sls' using 'yaml' renderer: 0.0014770030975341797
          [DEBUG   ] LazyLoaded file.managed
          [INFO    ] Running state [/tmp/salt_mapdata_dump.yaml] at time 09:53:30.671993
          [INFO    ] Executing state file.managed for [/tmp/salt_mapdata_dump.yaml]
          [DEBUG   ] LazyLoaded file.source_list
          [DEBUG   ] LazyLoaded cp.hash_file
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded roots.envs
          [DEBUG   ] Could not LazyLoad roots.init: 'roots.init' is not available.
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/_mapdata/_mapdata.jinja' to resolve 'salt://TEMPLATE/_mapdata/_mapdata.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/_mapdata/_mapdata.jinja' to resolve 'salt://TEMPLATE/_mapdata/_mapdata.jinja'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/_mapdata/_mapdata.jinja'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/_mapdata/_mapdata.jinja'
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [DEBUG   ] Using pkg_resources to load entry points
          [INFO    ] File changed:
          New file
          [INFO    ] Completed state [/tmp/salt_mapdata_dump.yaml] at time 09:53:30.763552 (duration_in_ms=91.56)
          [DEBUG   ] LazyLoaded pkg.install
          [DEBUG   ] LazyLoaded pkg.installed
          [DEBUG   ] LazyLoaded path.which
          [DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.dracr' from '/usr/lib/python3.8/site-packages/salt/modules/dracr.py'>
          [DEBUG   ] Reading configuration from /etc/salt/minion
          [DEBUG   ] Guessing ID. The id can be explicitly set in /etc/salt/minion
          [DEBUG   ] Found minion id from generate_minion_id(): 74230d4c8bf4
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Failed to import utils psutil_compat:
          Traceback (most recent call last):
            File "/usr/lib/python3.8/site-packages/salt/loader/lazy.py", line 766, in _load_module
              mod = self.run(spec.loader.load_module)
            File "/usr/lib/python3.8/site-packages/salt/loader/lazy.py", line 1201, in run
              return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
            File "/usr/lib/python3.8/site-packages/salt/loader/lazy.py", line 1216, in _run_as
              return _func_or_method(*args, **kwargs)
            File "<frozen importlib._bootstrap_external>", line 522, in _check_name_wrapper
            File "<frozen importlib._bootstrap_external>", line 1022, in load_module
            File "<frozen importlib._bootstrap_external>", line 847, in load_module
            File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
            File "<frozen importlib._bootstrap>", line 702, in _load
            File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
            File "<frozen importlib._bootstrap_external>", line 843, in exec_module
            File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
            File "/usr/lib/python3.8/site-packages/salt/utils/psutil_compat.py", line 14, in <module>
              import psutil  # pylint: disable=3rd-party-module-not-gated
          ModuleNotFoundError: No module named 'psutil'
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] Could not LazyLoad idem.hub: 'idem' __virtual__ returned False: No module named 'pop'
          [DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.kubeadm' from '/usr/lib/python3.8/site-packages/salt/modules/kubeadm.py'>
          [DEBUG   ] Override  __salt__: <module 'salt.loaded.int.module.udev' from '/usr/lib/python3.8/site-packages/salt/modules/udev.py'>
          [DEBUG   ] Override  __pillar__: <module 'salt.loaded.int.module.virtualenv_mod' from '/usr/lib/python3.8/site-packages/salt/modules/virtualenv_mod.py'>
          [DEBUG   ] DSC: Only available on Windows systems
          [DEBUG   ] Module PSGet: Only available on Windows systems
          [DEBUG   ] Could not LazyLoad pkg.ex_mod_init: 'pkg.ex_mod_init' is not available.
          [INFO    ] Running state [bash] at time 09:53:33.874002
          [INFO    ] Executing state pkg.installed for [bash]
          [DEBUG   ] Calling Zypper: zypper --non-interactive refresh --force
          [INFO    ] Executing command zypper in directory '/root'
          [INFO    ] Executing command rpm in directory '/root'
          [INFO    ] All specified packages are already installed
          [INFO    ] Completed state [bash] at time 09:53:47.616890 (duration_in_ms=13742.889)
          [INFO    ] Running state [/etc/TEMPLATE-subcomponent-formula.conf] at time 09:53:47.618682
          [INFO    ] Executing state file.managed for [/etc/TEMPLATE-subcomponent-formula.conf]
          [DEBUG   ] Returning file list from cache: age=18 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Returning file list from cache: age=18 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja' to resolve 'salt://TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja' to resolve 'salt://TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja'
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [INFO    ] File changed:
          New file
          [INFO    ] Completed state [/etc/TEMPLATE-subcomponent-formula.conf] at time 09:53:47.639992 (duration_in_ms=21.311)
          [INFO    ] Running state [/etc/template-formula.conf] at time 09:53:47.640442
          [INFO    ] Executing state file.managed for [/etc/template-formula.conf]
          [DEBUG   ] Returning file list from cache: age=18 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] Returning file list from cache: age=18 cache_time=20 /tmp/kitchen/var/cache/salt/minion/file_lists/roots/base.p
          [DEBUG   ] In saltenv 'base', looking at rel_path 'TEMPLATE/files/default/example.tmpl.jinja' to resolve 'salt://TEMPLATE/files/default/example.tmpl.jinja'
          [DEBUG   ] In saltenv 'base', ** considering ** path '/tmp/kitchen/var/cache/salt/minion/files/base/TEMPLATE/files/default/example.tmpl.jinja' to resolve 'salt://TEMPLATE/files/default/example.tmpl.jinja'
          [DEBUG   ] Fetching file from saltenv 'base', ** attempting ** 'salt://TEMPLATE/files/default/example.tmpl.jinja'
          [DEBUG   ] No dest file found
          [INFO    ] Fetching file from saltenv 'base', ** done ** 'TEMPLATE/files/default/example.tmpl.jinja'
          [DEBUG   ] Jinja search path: ['/tmp/kitchen/var/cache/salt/minion/files/base']
          [INFO    ] File changed:
          New file
          [INFO    ] Completed state [/etc/template-formula.conf] at time 09:53:47.654084 (duration_in_ms=13.643)
          [DEBUG   ] LazyLoaded service.running
          [INFO    ] Running state [systemd-journald] at time 09:53:47.666312
          [INFO    ] Executing state service.running for [systemd-journald]
          [INFO    ] Executing command systemctl in directory '/root'
          [DEBUG   ] stdout: * systemd-journald.service - Journal Service
               Loaded: loaded (/usr/lib/systemd/system/systemd-journald.service; static)
               Active: active (running) since Tue 2021-08-31 09:51:50 UTC; 1min 57s ago
          TriggeredBy: * systemd-journald-dev-log.socket
                * systemd-journald.socket
                * systemd-journald-audit.socket
          Docs: man:systemd-journald.service(8)
                man:journald.conf(5)
             Main PID: 29 (systemd-journal)
               Status: "Processing requests..."
                Tasks: 1
           CPU: 200ms
               CGroup: /system.slice/systemd-journald.service
                `-29 /usr/lib/systemd/systemd-journald
          [INFO    ] Executing command systemctl in directory '/root'
          [DEBUG   ] stdout: active
          [INFO    ] Executing command systemctl in directory '/root'
          [DEBUG   ] stdout: static
          [INFO    ] The service systemd-journald is already running
          [INFO    ] Completed state [systemd-journald] at time 09:53:48.098024 (duration_in_ms=431.712)
          [INFO    ] Running state [systemd-journald] at time 09:53:48.098381
          [INFO    ] Executing state service.mod_watch for [systemd-journald]
          [INFO    ] Executing command systemctl in directory '/root'
          [DEBUG   ] stdout: active
          [DEBUG   ] Could not LazyLoad service.full_restart: 'service.full_restart' is not available.
          [INFO    ] Executing command systemd-run in directory '/root'
          [DEBUG   ] stderr: Running scope as unit: run-r1b1b59720aa248d3a1db859cb3a77b41.scope
          [INFO    ] {'systemd-journald': True}
          [INFO    ] Completed state [systemd-journald] at time 09:53:48.633360 (duration_in_ms=534.979)
          [DEBUG   ] File /tmp/kitchen/var/cache/salt/minion/accumulator/140215878507968 does not exist, no need to cleanup
          [DEBUG   ] LazyLoaded state.check_result
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded highstate.output
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded nested.output
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded nested.output
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded nested.output
          [DEBUG   ] Using pkg_resources to load entry points
          [DEBUG   ] LazyLoaded nested.output
          local:
          ----------
                    ID: TEMPLATE-mapdata-dump
              Function: file.managed
                  Name: /tmp/salt_mapdata_dump.yaml
                Result: True
               Comment: File /tmp/salt_mapdata_dump.yaml updated
               Started: 09:53:30.671992
              Duration: 91.56 ms
               Changes:   
                 ----------
                 diff:
                     New file
                 mode:
                     0644
            Name: bash - Function: pkg.installed - Result: Clean Started: - 09:53:33.874001 Duration: 13742.889 ms
          ----------
                    ID: TEMPLATE-subcomponent-config-file-file-managed
              Function: file.managed
                  Name: /etc/TEMPLATE-subcomponent-formula.conf
                Result: True
               Comment: File /etc/TEMPLATE-subcomponent-formula.conf updated
               Started: 09:53:47.618681
              Duration: 21.311 ms
               Changes:   
                 ----------
                 diff:
                     New file
                 mode:
                     0644
          ----------
                    ID: TEMPLATE-config-file-file-managed
              Function: file.managed
                  Name: /etc/template-formula.conf
                Result: True
               Comment: File /etc/template-formula.conf updated
               Started: 09:53:47.640441
              Duration: 13.643 ms
               Changes:   
                 ----------
                 diff:
                     New file
                 mode:
                     0644
          ----------
                    ID: TEMPLATE-service-running-service-running
              Function: service.running
                  Name: systemd-journald
                Result: True
               Comment: Service restarted
               Started: 09:53:48.098381
              Duration: 534.979 ms
               Changes:   
                 ----------
                 systemd-journald:
                     True
          
          Summary for local
          ------------
          Succeeded: 5 (changed=4)
          Failed:    0
          ------------
          Total states run:     5
          Total run time:  14.404 s
          Downloading files from <default-opensuse-tmbl-latest-master-py3>
          Finished converging <default-opensuse-tmbl-latest-master-py3> (0m28.76s).
   -----> Setting up <default-opensuse-tmbl-latest-master-py3>...
          Finished setting up <default-opensuse-tmbl-latest-master-py3> (0m0.00s).
   -----> Verifying <default-opensuse-tmbl-latest-master-py3>...
          Loaded default 
   
   Profile: TEMPLATE formula (default)
   Version: (not specified)
   Target:  ssh://kitchen@localhost:49263
   
     ✔  TEMPLATE.subcomponent.config.file: Verify the subcomponent configuration file
        ✔  File /etc/TEMPLATE-subcomponent-formula.conf is expected to be file
        ✔  File /etc/TEMPLATE-subcomponent-formula.conf is expected to be owned by "root"
        ✔  File /etc/TEMPLATE-subcomponent-formula.conf is expected to be grouped into "root"
        ✔  File /etc/TEMPLATE-subcomponent-formula.conf mode is expected to cmp == "0644"
        ✔  File /etc/TEMPLATE-subcomponent-formula.conf content is expected to include "# File managed by Salt at <salt://TEMPLATE/subcomponent/config/files/default/subcomponent-example.tmpl.jinja>."
        ✔  File /etc/TEMPLATE-subcomponent-formula.conf content is expected to include "This is another subcomponent example file from SaltStack template-formula."
     ✔  TEMPLATE.package.install: The required package should be installed
        ✔  System Package bash is expected to be installed
     ✔  TEMPLATE._mapdata: `map.jinja` should match the reference file
        ✔  File content should match profile map data exactly
     ✔  TEMPLATE.service.running: The service should be installed, enabled and running
        ✔  Service systemd-journald is expected to be installed
        ✔  Service systemd-journald is expected to be enabled
        ✔  Service systemd-journald is expected to be running
     ✔  TEMPLATE.config.file: Verify the configuration file
        ✔  File /etc/template-formula.conf is expected to be file
        ✔  File /etc/template-formula.conf is expected to be owned by "root"
        ✔  File /etc/template-formula.conf is expected to be grouped into "root"
        ✔  File /etc/template-formula.conf mode is expected to cmp == "0644"
        ✔  File /etc/template-formula.conf content is expected to include "This is another example file from SaltStack template-formula."
        ✔  File /etc/template-formula.conf content is expected to include "\"added_in_pillar\": \"pillar_value\""
        ✔  File /etc/template-formula.conf content is expected to include "\"added_in_defaults\": \"defaults_value\""
        ✔  File /etc/template-formula.conf content is expected to include "\"added_in_lookup\": \"lookup_value\""
        ✔  File /etc/template-formula.conf content is expected to include "\"config\": \"/etc/template-formula.conf\""
        ✔  File /etc/template-formula.conf content is expected to include "\"lookup\": {\"added_in_lookup\": \"lookup_value\","
        ✔  File /etc/template-formula.conf content is expected to include "\"pkg\": {\"name\": \""
        ✔  File /etc/template-formula.conf content is expected to include "\"service\": {\"name\": \""
        ✔  File /etc/template-formula.conf content is expected to include "\"tofs\": {\"files_switch\": [\"any/path/can/be/used/here\", \"id\", \"roles\", \"osfinger\", \"os\"...inja\"], \"TEMPLATE-subcomponent-config-file-file-managed\": [\"subcomponent-example.tmpl.jinja\"]}"
        ✔  File /etc/template-formula.conf content is expected to include "\"arch\": \"amd64\""
        ✔  File /etc/template-formula.conf content is expected to include "\"winner\": \"pillar\"}"
        ✔  File /etc/template-formula.conf content is expected to include "winner of the merge: pillar"
   
   
   Profile: InSpec shared resources (share)
   Version: (not specified)
   Target:  ssh://kitchen@localhost:49263
   
        No tests executed.
   
   Profile Summary: 5 successful controls, 0 control failures, 0 controls skipped
   Test Summary: 27 successful, 0 failures, 0 skipped
          Finished verifying <default-opensuse-tmbl-latest-master-py3> (0m4.59s).
   -----> Test Kitchen is finished. (0m34.28s)
   ```
   </details>

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


This is incompatible with [cert-formula](https://github.com/saltstack-formulas/cert-formula) and PR #230.
