### PR TITLE
fix(libmapstack): allow mapping by booleans and numbers

### DIFF
--- a/TEMPLATE/libmapstack.jinja
+++ b/TEMPLATE/libmapstack.jinja
@@ -181,7 +181,7 @@
 {#-         Load YAML file matching the grain/pillar/... #}
 {#-         Fallback to use the source name as a direct filename #}
 
-{%-         if matcher.value | length == 0 %}
+{%-         if matcher.value is sequence and matcher.value | length == 0 %}
 {#-           Mangle `matcher.value` to use it as literal path #}
 {%-           set query_parts = matcher.query.split("/") %}
 {%-           set yaml_dirname = query_parts[0:-1] | join("/") %}
@@ -194,6 +194,11 @@
 {#-         Some configuration return list #}
 {%-         if yaml_names is string %}
 {%-           set yaml_names = [yaml_names] %}
+{%-         elif yaml_names is sequence %}
+{#-           Convert to strings if it's a sequence of numbers #}
+{%-           set yaml_names = yaml_names | map("string") | list %}
+{%-         else %}
+{%-           set yaml_names = [yaml_names | string] %}
 {%-         endif %}
 
 {#-         Try to load a `.yaml.jinja` file for each `.yaml` file #}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

If result of the lookup is a number, then map.jinja fails with `TypeError: object of type 'int' has no len()` here
https://github.com/saltstack-formulas/template-formula/blob/080fdcd9f136f19d2a7dd15b17bf4de5c1c4a3c8/TEMPLATE/libmapstack.jinja#L184
If result of the lookup is a list of numbers, then map.jinja fails with `Jinja variable 'int object' has no attribute 'rpartition'` here
https://github.com/saltstack-formulas/template-formula/blob/080fdcd9f136f19d2a7dd15b17bf4de5c1c4a3c8/TEMPLATE/libmapstack.jinja#L202
In this PR I tried to allow it to be numbers, booleans, list of numbers.

Usecases are:

* Uyuni or SUSE Manager exposes its groups as pillar value `group_ids` which is a list of integers: https://www.uyuni-project.org/uyuni-docs/en/uyuni/specialized-guides/salt/salt-custom-states.html#_apply_a_custom_state_at_highstate
* I can imagine someone might want to use mapping by `Y:G@efi` (returns boolean) or similar

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

`parameters/map_jinja.yaml`:
```yaml
values:
  sources:
    # default values
    - "Y:G@osarch"
    - "Y:G@os_family"
    - "Y:G@os"
    - "Y:G@osfinger"
    - "C@{{ tplroot ~ ':lookup' }}"
    - "C@{{ tplroot }}"

    - "Y:G@cpusockets"
    - "Y:I@group_ids"
    - "Y:G@efi"

    # default values
    - "Y:G@id"
```
and add some values to files
```
parameters/efi/False.yaml
parameters/efi/True.yaml
parameters/cpusockets/1.yaml
parameters/cpusockets/2.yaml
parameters/group_ids/14.yaml
parameters/group_ids/2.yaml
parameters/group_ids/26.yaml
```
`state.apply btrfsmaintenance._mapdata` should not fail, values should be present.

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


