### PR TITLE
ci(gitlab-ci): use Node `16.x` for `pre-commit` in test conversion job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,8 +137,12 @@ rubocop:
   cache: *cache_bundler
   before_script:
     - 'export CONVERTED=test-the-use_this_template-button'
-    - 'git clone . tmp/"${CONVERTED}"-formula'
-    - 'cd tmp/"${CONVERTED}"-formula'
+    - 'git clone . /tmp/"${CONVERTED}"-formula'
+    - 'cd /tmp/"${CONVERTED}"-formula'
+    # Limit the version of `node` used by `pre-commit`, to avoid the following error:
+    #   .../bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found
+    - 'echo "default_language_version:" >> .pre-commit-config.yaml'
+    - 'echo "  node: 16.14.2" >> .pre-commit-config.yaml'
     # Install `pre-commit` hooks
     - 'bin/install-hooks'
     # Run the conversion script with debug output


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [x] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

The `test_conversion` job failed during the weekly testing:

* https://gitlab.com/myii/template-formula/-/jobs/2371193438

The `stderr` being:

```
/root/.cache/pre-commit/repomigj3p4n/node_env-default/bin/node:
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found
(required by /root/.cache/pre-commit/repomigj3p4n/node_env-default/bin/node)
```

The following references led to this resolution:

* https://github.com/pre-commit/pre-commit/issues/2351
* https://stackoverflow.com/questions/71939099/bitbucket-pipeline-error-installing-pre-commit-ts-lint

As mentioned there:

> a few days ago node 18.x was released and the prebuilt binaries
> require a relatively-recent version of glibc

Which obviously isn't available on our current Bionic-based `dind` image,
i.e. 'myii/ssf-dind-ruby-bionic:2.7.5-1bbox1'.

While debugging this situation locally, noticed that the use of a
relative `tmp/...` subdirectory was within the `template-formula`
directory itself -- so switched this to using `/tmp/...` instead.



### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->