### PR TITLE
ci: update CI images for 2025-W09

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,8 +14,8 @@
   stage_test: &stage_test 'test'
   # `image`
   image_commitlint: &image_commitlint 'techneg/ci-commitlint:v1.1.76'
-  image_dindruby: &image_dindruby 'dafyddj/ci-dind-python-ruby:2.0.2'
-  image_dindrubybionic: &image_dindrubybionic 'dafyddj/ci-dind-python-ruby:2.0.2'
+  image_dindruby: &image_dindruby 'techneg/ci-docker-python-ruby:v2.2.45'
+  image_dindrubybionic: &image_dindrubybionic 'techneg/ci-docker-python-ruby:v2.2.45'
   image_precommit: &image_precommit 'techneg/ci-pre-commit:v2.4.10'
   image_rubocop: &image_rubocop 'pipelinecomponents/rubocop:latest'
   image_semantic-release: &image_semanticrelease 'myii/ssf-semantic-release:15.14'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@
   stage_release: &stage_release 'release'
   stage_test: &stage_test 'test'
   # `image`
-  image_commitlint: &image_commitlint 'myii/ssf-commitlint:11'
+  image_commitlint: &image_commitlint 'techneg/ci-commitlint:v1.1.76'
   image_dindruby: &image_dindruby 'dafyddj/ci-dind-python-ruby:2.0.2'
   image_dindrubybionic: &image_dindrubybionic 'dafyddj/ci-dind-python-ruby:2.0.2'
   image_precommit: &image_precommit 'techneg/ci-pre-commit:v2.4.10'


### PR DESCRIPTION
- **ci: update `ci-commitlint` to v1.1.76**
- **ci: update `ci-docker-python-ruby` to v2.2.45**
