### PR TITLE
ci: ignore `yamllint rule:line-length` for Docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@
   stage_release: &stage_release 'release'
   stage_test: &stage_test 'test'
   # `image`
+  # yamllint disable rule:line-length
   image_commitlint: &image_commitlint 'techneg/ci-commitlint:v1.1.76'
   image_dindruby: &image_dindruby 'techneg/ci-docker-python-ruby:v2.2.45'
   image_dindrubybionic: &image_dindrubybionic 'techneg/ci-docker-python-ruby:v2.2.45'
@@ -22,6 +23,7 @@
   # `services`
   services_docker_dind: &services_docker_dind
     - 'docker:dind'
+  # yamllint enable rule:line-length
   # `variables`
   # https://forum.gitlab.com/t/gitlab-com-ci-caching-rubygems/5627/3
   # https://bundler.io/v1.16/bundle_config.html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ ci:
   autoupdate_schedule: quarterly
   skip: []
   submodules: false
-default_stages: [commit]
+default_stages: [pre-commit]
 repos:
   - repo: https://github.com/dafyddj/commitlint-pre-commit-hook
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,3 +98,9 @@ repos:
     hooks:
       - id: renovate-config-validator
         name: Check Renovate config with renovate-config-validator
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.33.0
+    hooks:
+      - id: check-gitlab-ci
+        name: Check GitLab CI config with check-jsonschema
+        args: ["--verbose"]


### PR DESCRIPTION
- **ci: ignore `yamllint rule:line-length` for Docker images**
- **test(gitlab-ci): check GitLab CI config using `check-jsonschema`**
- **test(pre-commit): update deprecated stage name**
