### PR TITLE
chore: exclude Renovate commits from linting

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,4 +5,7 @@ module.exports = {
         'footer-max-line-length': [2, 'always', 120],
         'header-max-length': [2, 'always', 72],
     },
+    ignores: [
+        (commit) => commit.startsWith("chore(deps):")
+    ],
 };


### PR DESCRIPTION
  * as we need to limit commit message lengths and have limited control over
    this in Renovate
