### PR TITLE
ci(gitlab-ci): remove `py3` from instance names

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ rubocop:
     - 'bundle config set without "${BUNDLE_WITHOUT}"'
     - 'bundle install'
   script:
-    - 'bin/kitchen verify default-debian-11-master-py3'
+    - 'bin/kitchen verify default-debian-11-master'
 # REMOVEME>
 
 ###############################################################################
@@ -182,62 +182,62 @@ test-formula-conversion: {extends: '.test_conversion'}
 # OpenSUSE master branch will fail until zypperpkg module is back in salt core
 # https://github.com/saltstack/great-module-migration/issues/14
 #
-debian-12-master-py3: {extends: '.test_instance'}
-debian-11-master-py3: {extends: '.test_instance'}
-ubuntu-2404-master-py3: {extends: '.test_instance'}
-ubuntu-2204-master-py3: {extends: '.test_instance'}
-ubuntu-2004-master-py3: {extends: '.test_instance'}
-centos-stream9-master-py3: {extends: '.test_instance'}
-opensuse-leap-156-master-py3: {extends: '.test_instance_failure_permitted'}
-opensuse-leap-155-master-py3: {extends: '.test_instance'}
-opensuse-tmbl-latest-master-py3: {extends: '.test_instance'}
-amazonlinux-2023-master-py3: {extends: '.test_instance'}
-fedora-41-master-py3: {extends: '.test_instance_failure_permitted'}
-fedora-40-master-py3: {extends: '.test_instance'}
-oraclelinux-9-master-py3: {extends: '.test_instance'}
-oraclelinux-8-master-py3: {extends: '.test_instance'}
-almalinux-9-master-py3: {extends: '.test_instance'}
-almalinux-8-master-py3: {extends: '.test_instance'}
-rockylinux-9-master-py3: {extends: '.test_instance'}
-rockylinux-8-master-py3: {extends: '.test_instance'}
-debian-12-3007-2-py3: {extends: '.test_instance'}
-debian-11-3007-2-py3: {extends: '.test_instance'}
-ubuntu-2404-3007-2-py3: {extends: '.test_instance'}
-ubuntu-2204-3007-2-py3: {extends: '.test_instance'}
-ubuntu-2004-3007-2-py3: {extends: '.test_instance'}
-centos-stream9-3007-2-py3: {extends: '.test_instance'}
-opensuse-leap-156-3007-2-py3: {extends: '.test_instance'}
-opensuse-leap-155-3007-2-py3: {extends: '.test_instance'}
-opensuse-tmbl-latest-3007-2-py3: {extends: '.test_instance'}
-fedora-41-3007-2-py3: {extends: '.test_instance_failure_permitted'}
-fedora-40-3007-2-py3: {extends: '.test_instance'}
-amazonlinux-2-3007-2-py3: {extends: '.test_instance_failure_permitted'}
-amazonlinux-2023-3007-2-py3: {extends: '.test_instance'}
-oraclelinux-9-3007-2-py3: {extends: '.test_instance'}
-oraclelinux-8-3007-2-py3: {extends: '.test_instance'}
-almalinux-9-3007-2-py3: {extends: '.test_instance'}
-almalinux-8-3007-2-py3: {extends: '.test_instance'}
-rockylinux-9-3007-2-py3: {extends: '.test_instance'}
-rockylinux-8-3007-2-py3: {extends: '.test_instance'}
-debian-12-3006-10-py3: {extends: '.test_instance'}
-debian-11-3006-10-py3: {extends: '.test_instance'}
-ubuntu-2404-3006-10-py3: {extends: '.test_instance'}
-ubuntu-2204-3006-10-py3: {extends: '.test_instance'}
-ubuntu-2004-3006-10-py3: {extends: '.test_instance'}
-centos-stream9-3006-10-py3: {extends: '.test_instance'}
-opensuse-leap-156-3006-10-py3: {extends: '.test_instance'}
-opensuse-leap-155-3006-10-py3: {extends: '.test_instance'}
-opensuse-tmbl-latest-3006-10-py3: {extends: '.test_instance'}
-fedora-41-3006-10-py3: {extends: '.test_instance_failure_permitted'}
-fedora-40-3006-10-py3: {extends: '.test_instance'}
-amazonlinux-2-3006-10-py3: {extends: '.test_instance_failure_permitted'}
-amazonlinux-2023-3006-10-py3: {extends: '.test_instance'}
-oraclelinux-9-3006-10-py3: {extends: '.test_instance'}
-oraclelinux-8-3006-10-py3: {extends: '.test_instance'}
-almalinux-9-3006-10-py3: {extends: '.test_instance'}
-almalinux-8-3006-10-py3: {extends: '.test_instance'}
-rockylinux-9-3006-10-py3: {extends: '.test_instance'}
-rockylinux-8-3006-10-py3: {extends: '.test_instance'}
+debian-12-master: {extends: '.test_instance'}
+debian-11-master: {extends: '.test_instance'}
+ubuntu-2404-master: {extends: '.test_instance'}
+ubuntu-2204-master: {extends: '.test_instance'}
+ubuntu-2004-master: {extends: '.test_instance'}
+centos-stream9-master: {extends: '.test_instance'}
+opensuse-leap-156-master: {extends: '.test_instance_failure_permitted'}
+opensuse-leap-155-master: {extends: '.test_instance'}
+opensuse-tmbl-latest-master: {extends: '.test_instance'}
+amazonlinux-2023-master: {extends: '.test_instance'}
+fedora-41-master: {extends: '.test_instance_failure_permitted'}
+fedora-40-master: {extends: '.test_instance'}
+oraclelinux-9-master: {extends: '.test_instance'}
+oraclelinux-8-master: {extends: '.test_instance'}
+almalinux-9-master: {extends: '.test_instance'}
+almalinux-8-master: {extends: '.test_instance'}
+rockylinux-9-master: {extends: '.test_instance'}
+rockylinux-8-master: {extends: '.test_instance'}
+debian-12-3007-2: {extends: '.test_instance'}
+debian-11-3007-2: {extends: '.test_instance'}
+ubuntu-2404-3007-2: {extends: '.test_instance'}
+ubuntu-2204-3007-2: {extends: '.test_instance'}
+ubuntu-2004-3007-2: {extends: '.test_instance'}
+centos-stream9-3007-2: {extends: '.test_instance'}
+opensuse-leap-156-3007-2: {extends: '.test_instance'}
+opensuse-leap-155-3007-2: {extends: '.test_instance'}
+opensuse-tmbl-latest-3007-2: {extends: '.test_instance'}
+fedora-41-3007-2: {extends: '.test_instance_failure_permitted'}
+fedora-40-3007-2: {extends: '.test_instance'}
+amazonlinux-2-3007-2: {extends: '.test_instance_failure_permitted'}
+amazonlinux-2023-3007-2: {extends: '.test_instance'}
+oraclelinux-9-3007-2: {extends: '.test_instance'}
+oraclelinux-8-3007-2: {extends: '.test_instance'}
+almalinux-9-3007-2: {extends: '.test_instance'}
+almalinux-8-3007-2: {extends: '.test_instance'}
+rockylinux-9-3007-2: {extends: '.test_instance'}
+rockylinux-8-3007-2: {extends: '.test_instance'}
+debian-12-3006-10: {extends: '.test_instance'}
+debian-11-3006-10: {extends: '.test_instance'}
+ubuntu-2404-3006-10: {extends: '.test_instance'}
+ubuntu-2204-3006-10: {extends: '.test_instance'}
+ubuntu-2004-3006-10: {extends: '.test_instance'}
+centos-stream9-3006-10: {extends: '.test_instance'}
+opensuse-leap-156-3006-10: {extends: '.test_instance'}
+opensuse-leap-155-3006-10: {extends: '.test_instance'}
+opensuse-tmbl-latest-3006-10: {extends: '.test_instance'}
+fedora-41-3006-10: {extends: '.test_instance_failure_permitted'}
+fedora-40-3006-10: {extends: '.test_instance'}
+amazonlinux-2-3006-10: {extends: '.test_instance_failure_permitted'}
+amazonlinux-2023-3006-10: {extends: '.test_instance'}
+oraclelinux-9-3006-10: {extends: '.test_instance'}
+oraclelinux-8-3006-10: {extends: '.test_instance'}
+almalinux-9-3006-10: {extends: '.test_instance'}
+almalinux-8-3006-10: {extends: '.test_instance'}
+rockylinux-9-3006-10: {extends: '.test_instance'}
+rockylinux-8-3006-10: {extends: '.test_instance'}
 # yamllint enable rule:line-length
 
 ###############################################################################

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -26,227 +26,227 @@ transport:
 
 platforms:
   ## SALT `master`
-  - name: debian-12-master-py3
+  - name: debian-12-master
     driver:
       image: saltimages/salt-master-py3:debian-12
       run_command: /lib/systemd/systemd
-  - name: debian-11-master-py3
+  - name: debian-11-master
     driver:
       image: saltimages/salt-master-py3:debian-11
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2404-master-py3
+  - name: ubuntu-2404-master
     driver:
       image: saltimages/salt-master-py3:ubuntu-24.04
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2204-master-py3
+  - name: ubuntu-2204-master
     driver:
       image: saltimages/salt-master-py3:ubuntu-22.04
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2004-master-py3
+  - name: ubuntu-2004-master
     driver:
       image: saltimages/salt-master-py3:ubuntu-20.04
       run_command: /lib/systemd/systemd
-  - name: centos-stream9-master-py3
+  - name: centos-stream9-master
     driver:
       image: saltimages/salt-master-py3:centos-stream9
-  - name: opensuse-leap-156-master-py3
+  - name: opensuse-leap-156-master
     driver:
       image: saltimages/salt-master-py3:opensuse-leap-15.6
     # Workaround to avoid intermittent failures on `opensuse-leap-15.6`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: opensuse-leap-155-master-py3
+  - name: opensuse-leap-155-master
     driver:
       image: saltimages/salt-master-py3:opensuse-leap-15.5
     # Workaround to avoid intermittent failures on `opensuse-leap-15.5`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: opensuse-tmbl-latest-master-py3
+  - name: opensuse-tmbl-latest-master
     driver:
       image: saltimages/salt-master-py3:opensuse-tumbleweed-latest
     # Workaround to avoid intermittent failures on `opensuse-tumbleweed`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: fedora-41-master-py3
+  - name: fedora-41-master
     driver:
       image: saltimages/salt-master-py3:fedora-41
-  - name: fedora-40-master-py3
+  - name: fedora-40-master
     driver:
       image: saltimages/salt-master-py3:fedora-40
-  - name: amazonlinux-2023-master-py3
+  - name: amazonlinux-2023-master
     driver:
       image: saltimages/salt-master-py3:amazonlinux-2023
-  - name: oraclelinux-9-master-py3
+  - name: oraclelinux-9-master
     driver:
       image: saltimages/salt-master-py3:oraclelinux-9
-  - name: oraclelinux-8-master-py3
+  - name: oraclelinux-8-master
     driver:
       image: saltimages/salt-master-py3:oraclelinux-8
-  - name: almalinux-9-master-py3
+  - name: almalinux-9-master
     driver:
       image: saltimages/salt-master-py3:almalinux-9
-  - name: almalinux-8-master-py3
+  - name: almalinux-8-master
     driver:
       image: saltimages/salt-master-py3:almalinux-8
-  - name: rockylinux-9-master-py3
+  - name: rockylinux-9-master
     driver:
       image: saltimages/salt-master-py3:rockylinux-9
-  - name: rockylinux-8-master-py3
+  - name: rockylinux-8-master
     driver:
       image: saltimages/salt-master-py3:rockylinux-8
 
   ## SALT `3007.2`
-  - name: debian-12-3007-2-py3
+  - name: debian-12-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:debian-12
       run_command: /lib/systemd/systemd
-  - name: debian-11-3007-2-py3
+  - name: debian-11-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:debian-11
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2404-3007-2-py3
+  - name: ubuntu-2404-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:ubuntu-24.04
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2204-3007-2-py3
+  - name: ubuntu-2204-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:ubuntu-22.04
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2004-3007-2-py3
+  - name: ubuntu-2004-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:ubuntu-20.04
       run_command: /lib/systemd/systemd
-  - name: centos-stream9-3007-2-py3
+  - name: centos-stream9-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:centos-stream9
-  - name: opensuse-leap-155-3007-2-py3
+  - name: opensuse-leap-155-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:opensuse-leap-15.5
     # Workaround to avoid intermittent failures on `opensuse-leap-15.5`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: opensuse-leap-156-3007-2-py3
+  - name: opensuse-leap-156-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:opensuse-leap-15.6
     # Workaround to avoid intermittent failures on `opensuse-leap-15.6`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: opensuse-tmbl-latest-3007-2-py3
+  - name: opensuse-tmbl-latest-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:opensuse-tumbleweed-latest
     # Workaround to avoid intermittent failures on `opensuse-tumbleweed`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: fedora-41-3007-2-py3
+  - name: fedora-41-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:fedora-41
-  - name: fedora-40-3007-2-py3
+  - name: fedora-40-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:fedora-40
-  - name: amazonlinux-2023-3007-2-py3
+  - name: amazonlinux-2023-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:amazonlinux-2023
-  - name: amazonlinux-2-3007-2-py3
+  - name: amazonlinux-2-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:amazonlinux-2
-  - name: oraclelinux-9-3007-2-py3
+  - name: oraclelinux-9-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:oraclelinux-9
-  - name: oraclelinux-8-3007-2-py3
+  - name: oraclelinux-8-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:oraclelinux-8
-  - name: almalinux-9-3007-2-py3
+  - name: almalinux-9-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:almalinux-9
-  - name: almalinux-8-3007-2-py3
+  - name: almalinux-8-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:almalinux-8
-  - name: rockylinux-9-3007-2-py3
+  - name: rockylinux-9-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:rockylinux-9
-  - name: rockylinux-8-3007-2-py3
+  - name: rockylinux-8-3007-2
     driver:
       image: saltimages/salt-3007.2-py3:rockylinux-8
 
   ## SALT `3006.10`
-  - name: debian-12-3006-10-py3
+  - name: debian-12-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:debian-12
       run_command: /lib/systemd/systemd
-  - name: debian-11-3006-10-py3
+  - name: debian-11-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:debian-11
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2404-3006-10-py3
+  - name: ubuntu-2404-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:ubuntu-24.04
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2204-3006-10-py3
+  - name: ubuntu-2204-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:ubuntu-22.04
       run_command: /lib/systemd/systemd
-  - name: ubuntu-2004-3006-10-py3
+  - name: ubuntu-2004-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:ubuntu-20.04
       run_command: /lib/systemd/systemd
-  - name: centos-stream9-3006-10-py3
+  - name: centos-stream9-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:centos-stream9
-  - name: opensuse-tmbl-latest-3006-10-py3
+  - name: opensuse-tmbl-latest-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:opensuse-tumbleweed-latest
     # Workaround to avoid intermittent failures on `opensuse-tumbleweed`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: opensuse-leap-156-3006-10-py3
+  - name: opensuse-leap-156-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:opensuse-leap-15.6
     # Workaround to avoid intermittent failures on `opensuse-leap-15.6`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: opensuse-leap-155-3006-10-py3
+  - name: opensuse-leap-155-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:opensuse-leap-15.5
     # Workaround to avoid intermittent failures on `opensuse-leap-15.5`:
     # => SCP did not finish successfully (255):  (Net::SCP::Error)
     transport:
       max_ssh_sessions: 1
-  - name: fedora-41-3006-10-py3
+  - name: fedora-41-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:fedora-41
-  - name: fedora-40-3006-10-py3
+  - name: fedora-40-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:fedora-40
-  - name: amazonlinux-2023-3006-10-py3
+  - name: amazonlinux-2023-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:amazonlinux-2023
-  - name: amazonlinux-2-3006-10-py3
+  - name: amazonlinux-2-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:amazonlinux-2
-  - name: oraclelinux-9-3006-10-py3
+  - name: oraclelinux-9-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:oraclelinux-9
-  - name: oraclelinux-8-3006-10-py3
+  - name: oraclelinux-8-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:oraclelinux-8
-  - name: almalinux-9-3006-10-py3
+  - name: almalinux-9-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:almalinux-9
-  - name: almalinux-8-3006-10-py3
+  - name: almalinux-8-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:almalinux-8
-  - name: rockylinux-9-3006-10-py3
+  - name: rockylinux-9-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:rockylinux-9
-  - name: rockylinux-8-3006-10-py3
+  - name: rockylinux-8-3006-10
     driver:
       image: saltimages/salt-3006.10-py3:rockylinux-8
 


### PR DESCRIPTION
* `py3` is not meaningful at the moment as there is no sign of a Python 4
  and with `onedir` the version of Python used is not really of concern to
  the user
