### PR TITLE
ci(renovate): disable Bundler (Ruby Gems) updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   enabledManagers: [
-    'bundler',
     'github-actions',
     'gitlabci',
     'pre-commit',


### PR DESCRIPTION
* the intention is to manually keep Gemfile updated in line
  with the latest release of Chef Workstation
