### PR TITLE
ci: move towards releasing using GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Run `semantic-release`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAINTAINER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           semantic-release --dry-run
       - run: echo "::notice ::Workflow success!"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,10 +98,17 @@ jobs:
   results:
     name: Release / Collect results
     permissions:
+      contents: write
+      issues: write
+      pull-requests: write
       checks: read
+    container: techneg/ci-semantic-release:v1.0.1
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - run: |  # Needed due to bug actions/checkout#2031
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # yamllint disable-line rule:line-length
       - uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0
         with:
@@ -114,4 +121,9 @@ jobs:
             Test / Kitchen (ubuntu-2004-master)
           ignore_pattern: ^GitLab CI
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run `semantic-release`
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          semantic-release --dry-run
       - run: echo "::notice ::Workflow success!"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
       issues: write
       pull-requests: write
       checks: read
-    container: techneg/ci-semantic-release:v1.0.1
+    container: techneg/ci-semantic-release:v1.1.0
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,7 +273,6 @@ ubuntu-2004-3006-14: {extends: '.test_instance'}
 # `release` stage: `semantic-release`
 ###############################################################################
 semantic-release:
-  only: *only_branch_master_parent_repo
   stage: *stage_release
   image: *image_semanticrelease
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@
   image_dindrubybionic: &image_dindrubybionic 'techneg/ci-docker-python-ruby:v2.2.65@sha256:64753d90107a81f93ef1827d81f544b689165a9e5efc7494976bb6e11b8bbcc1'
   image_precommit: &image_precommit 'techneg/ci-pre-commit:v2.4.30@sha256:0d36fff14826b86f7248742a0e8f1d4b4d2341ebb9442dfe1d9c2491b63f3209'
   image_rubocop: &image_rubocop 'pipelinecomponents/rubocop:latest@sha256:fe69f9642c7edde46bbd78326d2c42c6e13fc73694efb142e92e206725479328'
-  image_semantic-release: &image_semanticrelease 'myii/ssf-semantic-release:15.14@sha256:374f588420087517a3cc0235e11293bffd72d7a59da3d98d5e69f014ff2a7761'
+  image_semantic-release: &image_semanticrelease 'techneg/ci-semantic-release:v1.1.0'
   # `services`
   services_docker_dind: &services_docker_dind
     - 'docker:28.3.2-dind@sha256:684bc226a69eb91582738f196e59e234355420ee592abea7685e4127afbce645'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,7 +278,5 @@ semantic-release:
   variables:
     MAINTAINER_TOKEN: '${GH_TOKEN}'
   script:
-    # Update `AUTHORS.md`
-    - '${HOME}/go/bin/maintainer contributor'
     # Run `semantic-release`
     - 'semantic-release'

--- a/pre-commit_semantic-release.sh
+++ b/pre-commit_semantic-release.sh
@@ -3,6 +3,7 @@
 ###############################################################################
 # (A) Update `FORMULA` with `${nextRelease.version}`
 ###############################################################################
+
 sed -i -e "s_^\(version:\).*_\1 ${1}_" FORMULA
 
 
@@ -13,16 +14,13 @@ sed -i -e "s_^\(version:\).*_\1 ${1}_" FORMULA
 maintainer contributor --ignore-contributors semantic-release-bot,renovate[bot]
 
 ###############################################################################
-# (C) Use `m2r2` to convert automatically produced `.md` docs to `.rst`
+# (C) Use `m2r` to convert automatically produced `.md` docs to `.rst`
 ###############################################################################
-
-# Install `m2r2`
-pip3 install m2r2
 
 # Copy and then convert the `.md` docs
 cp ./*.md docs/
 cd docs/ || exit
-m2r2 --overwrite ./*.md
+m2r --overwrite ./*.md
 
 # Change excess `H1` headings to `H2` in converted `CHANGELOG.rst`
 sed -i -e '/^=.*$/s/=/-/g' CHANGELOG.rst

--- a/pre-commit_semantic-release.sh
+++ b/pre-commit_semantic-release.sh
@@ -7,7 +7,13 @@ sed -i -e "s_^\(version:\).*_\1 ${1}_" FORMULA
 
 
 ###############################################################################
-# (B) Use `m2r2` to convert automatically produced `.md` docs to `.rst`
+# (B) Update `AUTHORS.md`
+###############################################################################
+
+maintainer contributor --ignore-contributors semantic-release-bot,renovate[bot]
+
+###############################################################################
+# (C) Use `m2r2` to convert automatically produced `.md` docs to `.rst`
 ###############################################################################
 
 # Install `m2r2`

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  branch: 'master',
   repositoryUrl: 'https://github.com/saltstack-formulas/template-formula',
   plugins: [
     ['@semantic-release/commit-analyzer', {

--- a/release.config.js
+++ b/release.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  // TODO: remove this when we no longer process releases on GitLab CI
   repositoryUrl: 'https://github.com/saltstack-formulas/template-formula',
   plugins: [
     ['@semantic-release/commit-analyzer', {
@@ -20,88 +21,6 @@ module.exports = {
     '@semantic-release/github'
   ],
   generateNotes: {
-    preset: 'angular',
-    writerOpts: {
-      // Required due to upstream bug preventing all types being displayed.
-      // Bug: https://github.com/conventional-changelog/conventional-changelog/issues/317
-      // Fix: https://github.com/conventional-changelog/conventional-changelog/pull/410
-      transform: (commit, context) => {
-        const issues = []
-
-        commit.notes.forEach(note => {
-          note.title = 'BREAKING CHANGES'
-        })
-
-        // NOTE: Any changes here must be reflected in `CONTRIBUTING.md`.
-        if (commit.type === 'feat') {
-          commit.type = 'Features'
-        } else if (commit.type === 'fix') {
-          commit.type = 'Bug Fixes'
-        } else if (commit.type === 'perf') {
-          commit.type = 'Performance Improvements'
-        } else if (commit.type === 'revert') {
-          commit.type = 'Reverts'
-        } else if (commit.type === 'docs') {
-          commit.type = 'Documentation'
-        } else if (commit.type === 'style') {
-          commit.type = 'Styles'
-        } else if (commit.type === 'refactor') {
-          commit.type = 'Code Refactoring'
-        } else if (commit.type === 'test') {
-          commit.type = 'Tests'
-        } else if (commit.type === 'build') {
-          commit.type = 'Build System'
-          // } else if (commit.type === `chore`) {
-          //     commit.type = `Maintenance`
-        } else if (commit.type === 'ci') {
-          commit.type = 'Continuous Integration'
-        } else {
-          return
-        }
-
-        if (commit.scope === '*') {
-          commit.scope = ''
-        }
-
-        if (typeof commit.hash === 'string') {
-          commit.shortHash = commit.hash.substring(0, 7)
-        }
-
-        if (typeof commit.subject === 'string') {
-          let url = context.repository
-            ? `${context.host}/${context.owner}/${context.repository}`
-            : context.repoUrl
-          if (url) {
-            url = `${url}/issues/`
-            // Issue URLs.
-            commit.subject = commit.subject.replace(/#([0-9]+)/g, (_, issue) => {
-              issues.push(issue)
-              return `[#${issue}](${url}${issue})`
-            })
-          }
-          if (context.host) {
-            // User URLs.
-            commit.subject = commit.subject.replace(/\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g, (_, username) => {
-              if (username.includes('/')) {
-                return `@${username}`
-              }
-
-              return `[@${username}](${context.host}/${username})`
-            })
-          }
-        }
-
-        // remove references that already appear in the subject
-        commit.references = commit.references.filter(reference => {
-          if (issues.indexOf(reference.issue) === -1) {
-            return true
-          }
-
-          return false
-        })
-
-        return commit
-      }
-    }
+    preset: 'angular'
   }
 }


### PR DESCRIPTION
- **feat(workflows): dry-run `semantic-release` in GitHub Actions**
- **ci(gitlab-ci): switch to image `techneg/ci-semantic-release`**
- **ci(gitlab-ci): remove deprecated keyword `only` for stage `release**
- **ci: use upstream `maintainer` with new `ignore` option**
- **ci(semantic-release): use `m2r` built in to image**
- **ci(semantic-release): defer to default `branches` values**
- **ci(semantic-release): config option no longer works**
