### PR TITLE
ci(workflows): no need to specify `bash` here

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,11 +46,10 @@ jobs:
           restore-keys: |
             ${{ env.CI_CACHE_ID }}|
       - name: Build cache
-        shell: bash
         run: |
           pre-commit gc
-          echo "Installing hook environments"
-          time pre-commit install-hooks
+          echo "Installing hook environments..."
+          time -f "Hook installation took %E" pre-commit install-hooks
       - name: Run `pre-commit`
         run: |
           pre-commit run --all-files --color always --verbose


### PR DESCRIPTION
*  as image contains the `time` command
