### PR TITLE
ci(renovate): enable auto-merging stable non-major updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,7 @@
     'github>saltstack-formulas/.github:groupManager(gitlabci,images)',
     'github>saltstack-formulas/.github:groupManager(pre-commit,hooks)',
     ':enablePreCommit',
+    ':automergeStableNonMajor',
   ],
   schedule: [
     '* 0-5 * * 2',        // Tuesdays before 6AM only


### PR DESCRIPTION
* now that we have rulesets with require status checks configured
* stable non-major updates are `minor` and `patch` updates
  where a package version is >= 1.0.
  (In Semantic Release version numbers below 1.0 are allowed to introduce
   breaking changes.)
