### PR TITLE
ci(gitlab-ci): avoid running `commitlint` job on default branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,10 @@ build-cache:
 commitlint:
   extends: '.lint_job'
   image: *image_commitlint
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: never
+    - when: on_success
   script:
     # Add `upstream` remote to get access to `upstream/master`
     - 'git remote add upstream


### PR DESCRIPTION
* Prior to `commitlint-cli` v21.0.2 providing the same commit as
  the `from` and `to` arguments failed silently.
  Skip running this job on the default branch (master) where this
  condition is present.
  `commitlint` is run in several other places to catch any problematic
  commit messages.
