### PR TITLE
revert(renovate): ignore `dind` versions v29.7+ until bugs are resolved

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,10 +25,5 @@
       matchDepTypes: ['uses-with'],
       enabled: false,
     },
-    {
-      // Ignore Docker `dind` versions v29.7 and later until bugs are resolved
-      matchDepNames: ['docker'],
-      allowedVersions: '<29.7',
-    },
   ],
 }


### PR DESCRIPTION
This reverts commit 41ae8bcfba28bbf6fe525257f4bdd33d6dd407ee.
